### PR TITLE
Add F# Interactive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,5 +54,8 @@ src/fsharp/FSharp.Core/Makefile
 src/fsharp/FSharp.Build/Makefile
 src/fsharp/FSharp.Compiler/Makefile
 src/fsharp/Fsc/Makefile
+src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile
+src/fsharp/FSharp.Compiler.Server.Shared/Makefile
+src/fsharp/fsi/Makefile
 ])
 AC_OUTPUT

--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile.in
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile.in
@@ -1,0 +1,36 @@
+NAME=FSharp.Compiler.Interactive.Settings
+ASSEMBLY = $(NAME).dll
+SIGN=1
+
+srcdir := @abs_srcdir@/
+
+include @abs_top_builddir@/config.make
+
+FSC=$(protodir)fsc-proto.exe
+
+FLAGS += \
+	$(FINAL_FLAGS) \
+	--target:library
+
+REFERENCES += \
+	-r:$(outdir)FSharp.Core.dll \
+	-r:Mono.Security.dll
+
+sources = \
+	../../assemblyinfo/assemblyinfo.FSharp.Compiler.Interactive.Settings.dll.fs \
+	../fsiaux.fsi \
+	../fsiaux.fs \
+	../fsiattrs.fs
+
+RESOURCES= \
+	$(tmpdir)FSInteractiveSettings.resources
+
+$(tmpdir)FSInteractiveSettings.resources: $(srcdir)../FSInteractiveSettings.txt
+	mono --debug $(FSSRGEN) $< $(@:.resources=.fs) $(@:.resources=.resx)
+	resgen $(@:.resources=.resx) $@
+
+include $(topdir)/src/fsharp/targets.make
+
+install: install-lib-2 install-lib-4
+
+

--- a/src/fsharp/FSharp.Compiler.Server.Shared/Makefile.in
+++ b/src/fsharp/FSharp.Compiler.Server.Shared/Makefile.in
@@ -1,0 +1,35 @@
+NAME=FSharp.Compiler.Server.Shared
+ASSEMBLY = $(NAME).dll
+SIGN=1
+
+srcdir := @abs_srcdir@/
+
+include @abs_top_builddir@/config.make
+
+FSC=$(protodir)fsc-proto.exe
+
+FLAGS += \
+	$(FINAL_FLAGS) \
+	--target:library
+
+REFERENCES += \
+	-r:$(outdir)FSharp.Core.dll \
+	-r:System.Runtime.Remoting.dll \
+	-r:Mono.Security.dll
+
+sources = \
+	../../assemblyinfo/assemblyinfo.FSharp.Compiler.Server.Shared.dll.fs \
+	../fsiserver/fsiserver.fs
+
+RESOURCES= \
+	$(tmpdir)FSServerShared.resources
+
+$(tmpdir)FSServerShared.resources: $(srcdir)../fsiserver/FSServerShared.txt
+	mono --debug $(FSSRGEN) $< $(@:.resources=.fs) $(@:.resources=.resx)
+	resgen $(@:.resources=.resx) $@
+
+include $(topdir)/src/fsharp/targets.make
+
+install: install-lib-2 install-lib-4
+
+

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -6,10 +6,15 @@ all clean do-2-0 do-4-0 clean-2-0 clean-4-0:
 	$(MAKE) -C FSharp.Build $@
 	$(MAKE) -C FSharp.Compiler $@
 	$(MAKE) -C Fsc $@
+	$(MAKE) -C FSharp.Compiler.Interactive.Settings $@
+	$(MAKE) -C FSharp.Compiler.Server.Shared $@
+	$(MAKE) -C fsi $@
 
 install:
 	$(MAKE) -C FSharp.Core $@
 	$(MAKE) -C FSharp.Build $@
 	$(MAKE) -C FSharp.Compiler $@
 	$(MAKE) -C Fsc $@
-
+	$(MAKE) -C FSharp.Compiler.Interactive.Settings $@
+	$(MAKE) -C FSharp.Compiler.Server.Shared $@
+	$(MAKE) -C fsi $@

--- a/src/fsharp/fsi/Makefile.in
+++ b/src/fsharp/fsi/Makefile.in
@@ -1,0 +1,41 @@
+NAME=fsi
+ASSEMBLY = $(NAME).exe
+SIGN=1
+
+srcdir := @abs_srcdir@/
+
+include @abs_top_builddir@/config.make
+
+FSC=$(protodir)fsc-proto.exe
+
+FLAGS += \
+	$(FINAL_FLAGS) \
+	--target:exe
+
+REFERENCES += \
+	-r:$(outdir)FSharp.Core.dll \
+	-r:$(outdir)FSharp.Compiler.dll \
+	-r:$(outdir)FSharp.Compiler.Interactive.Settings.dll \
+	-r:$(outdir)FSharp.Compiler.Server.Shared.dll \
+	-r:$(monolibdir)System.Windows.Forms.dll \
+	-r:$(monolibdir)System.Drawing.dll
+
+sources = \
+	$(tmpdir)FSIstrings.fs \
+	../../assemblyinfo/assemblyinfo.fsi.exe.fs \
+	../InternalCollections.fsi \
+	../InternalCollections.fs \
+	console.fs \
+	fsi.fs
+
+RESOURCES = \
+	$(tmpdir)FSIstrings.resources
+
+$(tmpdir)FSIstrings.resources: $(srcdir)/FSIstrings.txt
+	mono --debug $(FSSRGEN) $< $(@:.resources=.fs) $(@:.resources=.resx)
+	resgen $(@:.resources=.resx) $@
+
+include $(topdir)/src/fsharp/targets.make
+
+install: install-bin-2 install-bin-4
+

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -180,6 +180,7 @@ type FsiValuePrinter(ilGlobals,generateDebugInfo,resolvePath) =
                     yield DefaultPrintingIntercept];
               FloatingPointFormat = fsi.FloatingPointFormat;
               PrintWidth = fsi.PrintWidth; 
+
               PrintDepth = fsi.PrintDepth; 
               PrintLength = fsi.PrintLength;
               PrintSize = fsi.PrintSize;
@@ -1314,8 +1315,16 @@ module MagicAssemblyResolution =
     //  It is an explicit user trust decision to load an assembly with #r. Scripts are not run automatically (for example, by double-clicking in explorer).
     //  We considered setting loadFromRemoteSources in fsi.exe.config but this would transitively confer unsafe loading to the code in the referenced 
     //  assemblies. Better to let those assemblies decide for themselves which is safer.
+
 #if FX_ATLEAST_40
+
+    // Mono doesn't provide the UnsafeLoadFrom. LoadFrom works fine.
+#if MONO
+        Assembly.LoadFrom(path)
+#else
         Assembly.UnsafeLoadFrom(path)
+#endif
+
 #else
         Assembly.LoadFrom(path)
 #endif

--- a/src/fsharp/targets.make
+++ b/src/fsharp/targets.make
@@ -101,7 +101,7 @@ install-lib-2 install-lib-4:
 	$(INSTALL_LIB) $(outdir)Microsoft.FSharp.targets $(DESTDIR)/$(libdir)mono/$(TARGET)/;
 
 install-bin-2 install-bin-4:
-	sed -e 's,[@]DIR[@],$(libdir)mono/$(TARGET),g' -e 's,[@]TOOL[@],fsc.exe,g' < $(topdir)launcher.in > $(outdir)$(NAME)$(VERSION)
+	sed -e 's,[@]DIR[@],$(libdir)mono/$(TARGET),g' -e 's,[@]TOOL[@],$(ASSEMBLY),g' < $(topdir)launcher.in > $(outdir)$(NAME)$(VERSION)
 	chmod +x $(outdir)$(NAME)$(VERSION)
 	@mkdir -p $(DESTDIR)/$(libdir)
 	@mkdir -p $(DESTDIR)/$(bindir)


### PR DESCRIPTION
`fsharp/fsharp` master doesn't have any Makefiles to build fsi.exe and references.

Mono also has a bug that causes an error with compiling `src/fsharp/fsi/fsi.fs`:

https://bugzilla.novell.com/show_bug.cgi?id=665710
