### PR TITLE
Compile F# compiler, core libraries with optimizations enabled

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -32,7 +32,7 @@ TOKEN := b03f5f7f11d50a3a
 FLAGS = \
 	--doc:$(objdir)$(NAME).xml \
 	--version:$(VERSION) \
-	--debug- \
+	--debug:pdbonly \
 	--optimize+ \
 	--mlcompatibility \
 	--noframework \


### PR DESCRIPTION
The [Computer Language Benchmarks Game](http://shootout.alioth.debian.org/) shows that F# performance on Mono is noticeably less than the (roughly) equivalent C# solutions. Some of this difference can be attributed to the differences in implementation or the IL which is actually emitted by the C# and F# compilers.

However, I was poking around the F# sources a while back and noticed that if you simply pulled the sources and compiled them, the resulting F# compiler and core libraries were actually compiled with debugging information ON and optimizations OFF. I modified the `config.make.in` file so it sets the compiler flags to turn debugging information OFF and optimizations ON -- and I think that's a better default for almost everyone. Those interested in building experimental versions of F# should know enough to change it back ;)
