### PR TITLE
configure.ac: require Mono 2.9

### DIFF
--- a/README
+++ b/README
@@ -13,8 +13,7 @@ F# original powerpack sources are available from http://fsharppowerpack.codeplex
 
 ======= REQUIREMENTS =======
 
-Requires mono trunk, after September 23 - this is due to missing IStructuralComparable.CompareTo
-implementations, which F# requires and which were commited on 2010-09-23 on commit a57254256
+Requires mono 2.9 or higher.
 
 Requires bootstrapping libraries, tools and f# compiler. The lib/bootstrap/X.0 directories contain
 mono-built libraries, compiler and tools that can be used to bootstrap a build. You can also supply

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,14 @@ AC_INIT([fsharp], [0.1], [avidigal@novell.com])
 # Checks for programs.
 AC_PROG_MAKE_SET
 
+AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+if test "x$PKG_CONFIG" = "xno"; then
+        AC_MSG_ERROR([You need to install pkg-config])
+fi
+
+PKG_CHECK_MODULES([MONO], [mono >= 2.9])
+
+
 # Checks for libraries.
 
 # Checks for header files.


### PR DESCRIPTION
The README file was still kind of confusing in the Requirements section,
because:
a) It stated "mono trunk" instead of "mono master", as svn->git migration
happened already a while ago.
b) It mentioned a specific commit in mono instead of simply the lowest
Mono version that included this commit.

Looking at the commit, that fixes bug BNC#641146, it is dated on
September 2010 and went to the master branch:
https://bugzilla.novell.com/show_bug.cgi?id=641146

On August 2012, master branch gets labeled from "2.8.1" to "2.9":
http://lists.ximian.com/mailman/private/mono-patches/2010-October/178421.html

So we can safely assume that any Mono version equal or higher than
Mono 2.9 contains this fix. (The fix was backported too to the 2-8
branch but I still don't know which of the 2.8.x series included it;
at least I know it is not 2.8.1 as that is the version that the
reporter of the bug had.)
