### PR TITLE
Fix makefiles to symlink and generate things properly to keep xbuild happy

### DIFF
--- a/src/fsharp/Fsc/Makefile.in
+++ b/src/fsharp/Fsc/Makefile.in
@@ -33,5 +33,5 @@ $(tmpdir)FSCstrings.resources: $(srcdir)../FSCstrings.txt
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-bin-2 install-bin-4
+install: install-bin-2 install-bin-4 install-bin-4-5
 

--- a/src/fsharp/targets.make
+++ b/src/fsharp/targets.make
@@ -115,6 +115,11 @@ install-bin-2 install-bin-4:
 	$(INSTALL_LIB) $(outdir)$(ASSEMBLY) $(DESTDIR)$(libdir)mono/$(TARGET)
 	$(INSTALL_BIN) $(outdir)$(subst fs,fsharp,$(NAME))$(VERSION) $(DESTDIR)/$(bindir)
 
+install-bin-4-5: install-bin-4
+	@if test -e $(DESTDIR)$(libdir)mono/4.5/; then \
+		ln -fs $(DESTDIR)$(libdir)mono/4.0/$(ASSEMBLY) $(DESTDIR)$(libdir)mono/4.5/$(ASSEMBLY); \
+	fi
+
 $(objdir) $(objdir)$(TARGET_2_0) $(objdir)$(TARGET_4_0):
 	mkdir -p $@
 


### PR DESCRIPTION
With these set of patches, and one I'm going to commit to pull-request in mono master, xbuild finally generates assemblies out of the box, from F# projects created in VS2010, without the need of dirty
hacks like the ones mentioned in http://xtzgzorex.wordpress.com/2011/01/08/f-and-xbuild-debian/
