### PR TITLE
Play nice with hard tabs

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -455,8 +455,7 @@ rule token args skip = parse
        else WHITESPACE (LexCont.Token !args.ifdefStack) }
 
  | offwhite+  
-     { if args.lightSyntaxStatus.Status then errorR(Error(FSComp.SR.lexTabsNotAllowed(),lexbuf.LexemeRange));
-       if not skip then (WHITESPACE (LexCont.Token !args.ifdefStack)) else token args skip lexbuf }
+     { if not skip then (WHITESPACE (LexCont.Token !args.ifdefStack)) else token args skip lexbuf }
 
  | "////" op_char* 
      { // 4+ slash are 1-line comments, online 3 slash are XmlDoc 


### PR DESCRIPTION
A simple tweak to the lexer allows fsharp to play nice with hard tabs. Avoid code politics!
