### PR TITLE
FSharp.Core.dll for net4+sl4+wp71+win8  (Fix #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,17 @@ msbuild fsharp-proto-build.proj
 msbuild fsharp-library-build.proj
 msbuild fsharp-compiler-build.proj
 ```
-You can also build the FSharp.Core for .NET 2.0, Mono 2.1 and Silverlight 5.0 profiles:
+You can also build the FSharp.Core for .NET 2.0, Mono 2.1, Silverlight 5.0 and Portable Profile47 (net4+sl4+wp71+win8) profiles:
 ```
 msbuild fsharp-library-build.proj /p:TargetFramework=net20 
 msbuild fsharp-library-build.proj /p:TargetFramework=mono21
+msbuild fsharp-library-build.proj /p:TargetFramework=portable-net4+sl4+wp71+win8
 msbuild fsharp-library-build.proj /p:TargetFramework=sl5
 ```
-
 You can also build the FSharp.Core and FSharp.Compiler.Silverlight.dll for Silverlight 5.0:
 ```
 msbuild fsharp-library-build.proj /p:TargetFramework=sl5-compiler 
 msbuild fsharp-compiler-build.proj /p:TargetFramework=sl5-compiler
-```
-And for Release versions of the same:
-```
-msbuild fsharp-library-build.proj /p:Configuration=Release
-msbuild fsharp-compiler-build.proj /p:Configuration=Release
-msbuild fsharp-library-build.proj /p:TargetFramework=net20 /p:Configuration=Release
-msbuild fsharp-library-build.proj /p:TargetFramework=mono21 /p:Configuration=Release
-msbuild fsharp-library-build.proj /p:TargetFramework=sl5  /p:Configuration=Release
-msbuild fsharp-library-build.proj /p:TargetFramework=sl5-compiler  /p:Configuration=Release
-msbuild fsharp-compiler-build.proj /p:TargetFramework=sl5-compiler  /p:Configuration=Release
 ```
 ### On Windows, using xbuild (e.g. if no .NET is installed and only Mono 3.0 is installed):
 

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -12,7 +12,6 @@
     <protoCLIDir>4.0</protoCLIDir>
     <LkgPath>$(FSharpSourcesRoot)\..\lib\bootstrap\4.0</LkgPath>
     <FsLexUnicode>true</FsLexUnicode>
-    <ProjectLanguage>FSharp</ProjectLanguage>
     <OtherFlags>$(OtherFlags) --times</OtherFlags>
     <NoWarn>$(NoWarn);69;65;54;61;75</NoWarn>
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +22,14 @@
     <VersionFile>$(FSharpSourcesRoot)\source-build-version</VersionFile>
     <VersionFile Condition="'$(TargetFramework)' == 'net20'">$(FSharpSourcesRoot)\source-build-version-2.3.0.0</VersionFile>
     <VersionFile Condition="'$(TargetFramework)' == 'net40'">$(FSharpSourcesRoot)\source-build-version-4.3.0.0</VersionFile>
+    <VersionFile Condition="'$(TargetFramework)' == 'portable-net4+sl4+wp71+win8'">$(FSharpSourcesRoot)\source-build-version-2.3.5.0</VersionFile>
+<!--
+Some other NuGET monikers to support in the future, see http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-package#Package_Conventions
+
+    <VersionFile Condition="'$(TargetFramework)' == 'portable-windows8+net45'">$(FSharpSourcesRoot)\source-build-version-2.3.6.0</VersionFile>
+    <VersionFile Condition="'$(TargetFramework)' == 'windows8'">$(FSharpSourcesRoot)\source-build-version-2.3.7.0</VersionFile>
+    <VersionFile Condition="'$(TargetFramework)' == 'windowsphone8'">$(FSharpSourcesRoot)\source-build-version-2.3.8.0</VersionFile>
+-->
   </PropertyGroup>
 
   <!-- We sign FSharp.Core with the Microsoft key and use delay-signing. -->
@@ -58,11 +65,13 @@
     <!-- These flags provide a better debugging experience. Locals should be visible. -->
     <OtherFlags>$(OtherFlags) --no-jit-optimize --jit-tracking</OtherFlags>
     <DefineConstants>CODE_ANALYSIS; $(DefineConstants)</DefineConstants>
+    <BuildWith>LKG</BuildWith>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
     <ConfigurationOutputDirectory>release</ConfigurationOutputDirectory>
+    <BuildWith>LKG</BuildWith>
   </PropertyGroup>
 
   <!-- Flags used to build the bootstrap compiler.
@@ -82,7 +91,7 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net20'">
     <!-- If 3.5 is not configured explicitly, use 2.0 -->
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)'==''">v2.0</TargetFrameworkVersion>
-    <TargetFrameworkVersionShort>2.0</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>2.0</TargetFrameworkOutputDirectory>
     <DefineConstants>$(DefineConstants);FX_NO_STRUCTURAL_EQUALITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CANCELLATIONTOKEN_CLASSES</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TASK</DefineConstants>
@@ -98,7 +107,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkVersionShort>4.0</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>4.0</TargetFrameworkOutputDirectory>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_40</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_35</DefineConstants>
     <DefineConstants>$(DefineConstants);BE_SECURITY_TRANSPARENT</DefineConstants>
@@ -113,7 +122,7 @@
   <!-- Target MonoAndroid and MonoTouch -->
   <PropertyGroup Condition="'$(TargetFramework)'=='mono21'">
     <TargetFrameworkVersion>v2.1</TargetFrameworkVersion>
-    <TargetFrameworkVersionShort>2.1</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>2.1</TargetFrameworkOutputDirectory>
     <DefineConstants>$(DefineConstants);FX_NO_STRUCTURAL_EQUALITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CUSTOMATTRIBUTEDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_BIGINT_CULTURE_PARSE</DefineConstants>
@@ -125,10 +134,70 @@
   </PropertyGroup>
 
 
+  <!-- Target Portable -->
+  <PropertyGroup Condition="'$(TargetFramework)'=='portable-net4+sl4+wp71+win8'">
+
+    <TargetFrameworkProfile>Profile47</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkOutputDirectory>$(TargetFramework)</TargetFrameworkOutputDirectory>
+
+    <DefineConstants>$(DefineConstants);FSHARP_CORE_PORTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_CONCURRENT_DICTIONARY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_ATLEAST_PORTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_ARRAY_LONG_LENGTH</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_DEBUG_PROXIES</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_EXIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_CHAR_PARSE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_DEFAULT_DEPENDENCY_TYPE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_SIMPLE_SECURITY_PERMISSIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_TRUNCATE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_CULTURE_INFO_ARGS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_MODULES</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_METADATA_TOKENS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_TO_LOWER_INVARIANT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_EXIT_CONTEXT_FLAGS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BASED_ARRAYS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_DOUBLE_BIT_CONVERTER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BINARY_SERIALIZATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_ASCII_ENCODING</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_DEFAULT_ENCODING</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_FILE_OPTIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_NONBLOCK_IO</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_COMMAND_LINE_ARGS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_ENVIRONMENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_PROCESS_START</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_APP_DOMAINS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_PROCESS_DIAGNOSTICS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_IOBSERVABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WEB_CLIENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_CONVERTER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_GET_HASH_CODE_HELPER</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_COMVISIBLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_ICLONEABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_SECURITY_PERMISSIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_SYSTEM_CONSOLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_ARRAY_KEY_SORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_EMIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_PARAMETERIZED_THREAD_START</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_EVENTWAITHANDLE_NO_IDISPOSABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_REGISTERED_WAIT_HANDLES</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_ATLEAST_LINQ</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_THREAD</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_THREADPOOL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_WAITONE_MILLISECONDS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_TPL_PARALLEL</DefineConstants>
+    <DefineConstants>$(DefineConstants);PUT_TYPE_PROVIDERS_IN_FSCORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_CUSTOMATTRIBUTEDATA</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>
+    <DefineConstants>$(DefineConstants);DONT_INCLUDE_DEPRECATED</DefineConstants>
+    <DefineConstants>$(DefineConstants);PUT_TYPE_PROVIDERS_IN_FSCORE</DefineConstants>
+
+  </PropertyGroup>
+
   <!-- Target Silverlight 3.0 -->
   <PropertyGroup Condition="'$(TargetFramework)'=='sl3'">
     <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
-    <TargetFrameworkVersionShort>sl3</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>sl3</TargetFrameworkOutputDirectory>
     <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CANCELLATIONTOKEN_CLASSES</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_TASK</DefineConstants>
@@ -207,7 +276,7 @@
     <DefineConstants>$(DefineConstants);FX_ATLEAST_LINQ</DefineConstants>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkVersionShort>sl4</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>sl4</TargetFrameworkOutputDirectory>
     <SilverlightVersion>v4.0</SilverlightVersion>
   </PropertyGroup>
 
@@ -253,12 +322,12 @@
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <SilverlightVersion>v5.0</SilverlightVersion>
-    <TargetFrameworkVersionShort>$(TargetFramework)</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>$(TargetFramework)</TargetFrameworkOutputDirectory>
     <FrameworkRegistryBase>Software\Microsoft\Microsoft SDKs\$(TargetFrameworkIdentifier)</FrameworkRegistryBase>
     <AssemblySearchPaths>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\Framework\Silverlight\v5.0</AssemblySearchPaths>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='sl3-wp'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='wp7'">
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>WindowsPhone</TargetFrameworkProfile>
     <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
@@ -300,7 +369,7 @@
     <DefineConstants>$(DefineConstants);FX_ATLEAST_LINQ</DefineConstants>
     <Tailcalls>false</Tailcalls>
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
-    <TargetFrameworkVersionShort>$(TargetFramework)</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>$(TargetFramework)</TargetFrameworkOutputDirectory>
     <!-- It would be better to use MSBuild resolution here, but the TargetFrameworkIdentifier etc. aren't set up quite correctly as yet -->
     <OtherFlags>$(OtherFlags) --simpleresolution -r:"C:\Program Files\Reference Assemblies\Microsoft\Framework\Silverlight\v4.0\Profile\WindowsPhone\mscorlib.dll" </OtherFlags>
   </PropertyGroup>
@@ -351,7 +420,7 @@
     <DefineConstants>$(DefineConstants);FX_NO_TUPLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_DELEGATE_CREATE_DELEGATE_FROM_STATIC_METHOD</DefineConstants>
     <DefineConstants>$(DefineConstants)</DefineConstants>
-    <TargetFrameworkVersionShort>$(TargetFramework)</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>$(TargetFramework)</TargetFrameworkOutputDirectory>
     <!-- It would be better to use MSBuild resolution here, but the TargetFrameworkIdentifier etc. aren't set up quite correctly as yet -->
     <OtherFlags>$(OtherFlags) --simpleresolution -r:"C:\Program Files\Microsoft.NET\SDK\CompactFramework\v2.0\WindowsCE\mscorlib.dll"  -r:"C:\Program Files\Microsoft.NET\SDK\CompactFramework\v2.0\WindowsCE\System.dll"</OtherFlags>
   </PropertyGroup>
@@ -396,7 +465,7 @@
   <!-- Target CompactFramework 3.5 -->
   <PropertyGroup Condition="'$(TargetFramework)'=='net35-cf'">
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <TargetFrameworkVersionShort>3.5</TargetFrameworkVersionShort>
+    <TargetFrameworkOutputDirectory>3.5</TargetFrameworkOutputDirectory>
     <TargetFrameworkIdentifier>CompactFramework</TargetFrameworkIdentifier>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_COMPACT_FRAMEWORK_35</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_CANCELLATIONTOKEN_CLASSES</DefineConstants>
@@ -446,31 +515,35 @@
 
   <!-- Always qualify the IntermediateOutputPath by the TargetFramework if any exists -->
   <PropertyGroup>
-    <IntermediateOutputPath>obj\$(ConfigurationOutputDirectory)\$(TargetFrameworkVersionShort)\</IntermediateOutputPath>
+    <IntermediateOutputPath>obj\$(ConfigurationOutputDirectory)\$(TargetFrameworkOutputDirectory)\</IntermediateOutputPath>
   </PropertyGroup>
 
   <!-- Build with LKG compiler (location is determined by Microsoft.FSharp.Targets). The output compiler has suffix "-proto" -->
-  <PropertyGroup Condition=" '$(BuildWith)' == 'LKG' And '$(ProjectLanguage)' == 'FSharp' ">
+  <PropertyGroup Condition=" '$(BuildWith)' == 'LKG'">
     <FsBuildSuffix>-proto</FsBuildSuffix>
-    <OutputPath>$(FSharpSourcesRoot)\..\lib\$(ConfigurationOutputDirectory)\$(TargetFrameworkVersionShort)</OutputPath>
+    <OutputPath>$(FSharpSourcesRoot)\..\lib\$(ConfigurationOutputDirectory)\$(TargetFrameworkOutputDirectory)</OutputPath>
   </PropertyGroup>
 
   <!-- Build with prototype compiler (location is given by settings below). The output is the final bootstrapped compiler -->
   <PropertyGroup Condition=" '$(BuildWith)' == ''">
     <FscToolPath>$(FSharpSourcesRoot)\..\lib\proto\$(protoCLIDir)</FscToolPath>
     <FscToolExe>fsc-proto.exe</FscToolExe>
-    <OutputPath>$(FSharpSourcesRoot)\..\lib\$(ConfigurationOutputDirectory)\$(TargetFrameworkVersionShort)</OutputPath>
+    <OutputPath>$(FSharpSourcesRoot)\..\lib\$(ConfigurationOutputDirectory)\$(TargetFrameworkOutputDirectory)</OutputPath>
   </PropertyGroup>
 
 
-
-  <!-- Include the proto targets file when building the final compiler suing the proto -->
+  <!-- Include the proto targets file when building the final compiler using the proto -->
   <Import Project="..\lib\proto\$(protoCLIDir)\Microsoft.FSharp-proto.targets" 
-          Condition="Exists('..\lib\proto\$(protoCLIDir)\Microsoft.FSharp-proto.targets') AND '$(BuildWith)' == '' AND '$(ProjectLanguage)' == 'FSharp' "/>
+          Condition="Exists('..\lib\proto\$(protoCLIDir)\Microsoft.FSharp-proto.targets') AND '$(BuildWith)' == ''"/>
+
+  <!-- Include the portable targets file when building the portable FSharp.Core -->
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets"
+          Condition="'$(TargetFramework)'=='portable-net4+sl4+wp71+win8'"/>
+
   <!-- Include the bootstrap targets file when building the proto compiler using the bootstrap -->
   <!-- Also include it if Proto targets file doesn't exist, e.g. when cleaning the build with /t:Clean -->
   <Import Project="$(LkgPath)\Microsoft.FSharp.Targets"  
-          Condition="(!Exists('..\lib\proto\$(protoCLIDir)\Microsoft.FSharp-proto.targets')  OR '$(BuildWith)' == 'LKG') AND '$(ProjectLanguage)' == 'FSharp'" />
+          Condition="(!Exists('..\lib\proto\$(protoCLIDir)\Microsoft.FSharp-proto.targets')  OR '$(BuildWith)' == 'LKG') " />
   <Import Project="Silverlight\$(SilverlightVersion)\FSharpSource.Silverlight.Common.targets"
           Condition="'$(TargetFramework)'=='sl3' or '$(TargetFramework)'=='sl4' or '$(TargetFramework)'=='sl5' or '$(TargetFramework)'=='sl5-compiler'"/>
 
@@ -497,13 +570,14 @@
             Text="Configuration '$(Configuration)' is not one of the supported configurations: Debug, Release, Proto"
             Condition="'$(Configuration)'!='Release' and '$(Configuration)'!='Debug' and '$(Configuration)'!='Proto'"/>
     <Error
-            Text="TargetFramework '$(TargetFramework)' is not one of the supported configurations: 'empty', net20, net40, mono21, sl3-wp, sl5, sl5-compiler"
+            Text="TargetFramework '$(TargetFramework)' is not one of the supported configurations: 'empty', net20, net40, mono21, wp7, sl5, sl5-compiler, portable-net4+sl4+wp71+win8"
             Condition="! ('$(TargetFramework)' == 'net40' or 
                           '$(TargetFramework)' == 'net20' or 
                           '$(TargetFramework)' == 'mono21' or 
                           '$(TargetFramework)' == 'sl5' or 
                           '$(TargetFramework)' == 'sl5-compiler' or 
-                          '$(TargetFramework)' == 'sl3-wp')"/>
+                          '$(TargetFramework)' == 'wp7' or 
+                          '$(TargetFramework)' == 'portable-net4+sl4+wp71+win8')"/>
   </Target>
 
   <Import Project="$(LkgPath)\..\2.0\FSharp.SRGen.targets" />

--- a/src/fsharp-library-unittests-build.proj
+++ b/src/fsharp-library-unittests-build.proj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <!-- Core library tests: all except compact framework (no nunit there) -->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'sl3-wp' and '$(TargetFramework)' != 'sl5'">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'wp7' and '$(TargetFramework)' != 'sl5'">
     <ProjectFiles Include="fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj"/>
   </ItemGroup>
 

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
@@ -41,21 +41,21 @@
     <DebugSymbols>False</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework" Condition="'$(TargetFramework)' != 'sl5' AND '$(TargetFramework)' != 'sl5-compiler' AND '$(TargetFramework)' != 'sl3-wp'" />
-    <Reference Include="NUnitFramework" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl3-wp' OR '$(TargetFramework)' == 'sl5-compiler'" />
+    <Reference Include="nunit.framework" Condition="'$(TargetFramework)' != 'sl5' AND '$(TargetFramework)' != 'sl5-compiler' AND '$(TargetFramework)' != 'wp7'" />
+    <Reference Include="NUnitFramework" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'wp7' OR '$(TargetFramework)' == 'sl5-compiler'" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Numerics" Condition="'$(TargetFramework)' == 'net40'" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl5-compiler' " />
-    <Reference Include="System.Observable" Condition="'$(TargetFramework)' == 'sl3-wp' " />
+    <Reference Include="System.Observable" Condition="'$(TargetFramework)' == 'wp7' " />
     <ProjectReference Include="..\FSharp.Core\FSharp.Core.fsproj">
       <Project>{DED3BBD7-53F4-428A-8C9F-27968E768605}</Project>
       <Name>FSharp.Core</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="NUnitFrameworkShims.fs" Condition="'$(TargetFramework)' == 'sl3-wp'" />
+    <Compile Include="NUnitFrameworkShims.fs" Condition="'$(TargetFramework)' == 'wp7'" />
     <Compile Include="LibraryTestFx.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\ArrayModule.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\ArrayModule2.fs" />

--- a/src/fsharp/FSharp.Core/FSharp.Core.fsproj
+++ b/src/fsharp/FSharp.Core/FSharp.Core.fsproj
@@ -215,9 +215,9 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Numerics" Condition="'$(TargetFramework)' == 'net40'" />
-    <Reference Include="System.Net" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl5-compiler' OR '$(TargetFramework)' == 'XNA\5.0' OR '$(TargetFramework)' == 'sl3-wp' " />
-    <Reference Include="System.Observable" Condition="'$(TargetFramework)' == 'sl3-wp' " />
-    <Reference Include="System.Core" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl5-compiler' OR '$(TargetFramework)' == 'XNA\5.0' OR '$(TargetFramework)' == 'sl3-wp' " />
+    <Reference Include="System.Net" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl5-compiler' OR '$(TargetFramework)' == 'XNA\5.0' OR '$(TargetFramework)' == 'wp7' OR '$(TargetFramework)' == 'portable-net4+sl4+wp71+win8' " />
+    <Reference Include="System.Observable" Condition="'$(TargetFramework)' == 'wp7' " />
+    <Reference Include="System.Core" Condition="'$(TargetFramework)' == 'sl5' OR '$(TargetFramework)' == 'sl5-compiler' OR '$(TargetFramework)' == 'XNA\5.0' OR '$(TargetFramework)' == 'wp7' OR '$(TargetFramework)' == 'portable-net4+sl4+wp71+win8'  " />
   </ItemGroup>
   <!-- References -->
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.targets" />

--- a/src/fsharp/FSharp.Data.TypeProviders/FSharp.Data.TypeProviders.fsproj
+++ b/src/fsharp/FSharp.Data.TypeProviders/FSharp.Data.TypeProviders.fsproj
@@ -21,7 +21,7 @@
   <ItemGroup>                             
     <!--This is used for compiling the run2ype provider DLL for WP7, Silverlight etc. -->
     <!--This is the only file used. -->
-    <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Data.TypeProviders\TypeProviderRuntimeAttribute.fs"   Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'sl3-wp' or '$(TargetFramework)'=='sl4' ">
+    <Compile Include="$(FSharpSourcesRoot)\fsharp\FSharp.Data.TypeProviders\TypeProviderRuntimeAttribute.fs"   Condition="'$(TargetFramework)' == 'net20' or '$(TargetFramework)' == 'wp7' or '$(TargetFramework)'=='sl4' ">
       <Link>TypeProviderRuntimeAttribute.fs</Link>
       <Visible>true</Visible>
     </Compile>


### PR DESCRIPTION
This fixes https://github.com/fsharp/fsharp/issues/79

F# 3.0 supports portable Profile47 (called portable-net4+sl4+wp71+win8 in Nuget). This adds a build of the corresponding FSharp.Core. The list of defines comes from the F# 3.0 source code drop on codeplex.

The FSharp.Core can currently only be built on Windows as it needs the portable profile reference assemblies.
