### PR TITLE
configure: do not use SGen if Mono < 3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,11 +19,14 @@ if ! pkg-config --atleast-version=$MONO_REQUIRED_VERSION mono; then
 	AC_MSG_ERROR("You need mono $MONO_REQUIRED_VERSION")
 fi
 
+AC_PATH_PROG(MONO_SGEN, mono-sgen, no)
+
 if ! pkg-config --atleast-version=$MONO_RECOMMENDED_VERSION mono; then
 	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, for better MSBuild (xbuild) compatibility])
-fi
 
-AC_PATH_PROG(MONO_SGEN, mono-sgen, no)
+	# stability of Mono's SGEN GC is not so good in older versions than Mono v3.0
+	MONO_SGEN=no
+fi
 
 # Checks for libraries.
 


### PR DESCRIPTION
As pointed out in https://github.com/fsharp/fsharp/issues/86 , Mono 2.10.x
may be still too unstable to use Mono's generational garbage collector.
