### PR TITLE
Suggestion: autogen.sh: remove aclocal calls, not needed anymore

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
 which autoreconf > /dev/null || (echo "Please install autoconf" && exit 1)
-# on OSX autoconf may need a little help with these paths
-aclocal -I /opt/local/share/aclocal -I /usr/local/share/aclocal 2> /dev/null
 autoreconf && ./configure $@


### PR DESCRIPTION
Since we stopped using autoconf macros (such as PKG_CHECK_MODULES;
see [1]) in [2], aclocal is not likely to be needed anymore.

[1] http://tirania.org/blog/archive/2012/Oct-20.html
[2] https://github.com/fsharp/fsharp/commit/cded42fb1929f9ca1edcb5ecc38c052287caba0e
