### PR TITLE
Fixed link to F# Software Foundation

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ commit your changes and send a pull request.</p>
 <br />
 <br />
 <p>This project is part of the <a href="http://fsharp.github.com">F# Open Source Group</a>, a 
-working group of the <a href="htp://fsharp.org">F# Software Foundation</a>. 
+working group of the <a href="http://fsharp.org">F# Software Foundation</a>. 
 <a href="https://github.com/fsharp/fsharp/edit/gh-pages/index.html">edit</a></p>
 </body>
 </html>


### PR DESCRIPTION
Protocol should be http, not htp
