### PR TITLE
Fix #68: Add build of FSharp.Data.TypeProivders.dll to open source edition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ src/fsharp/FSharp.Compiler/Makefile
 src/fsharp/Fsc/Makefile
 src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile
 src/fsharp/FSharp.Compiler.Server.Shared/Makefile
+src/fsharp/FSharp.Data.TypeProviders/Makefile
 src/fsharp/fsi/Makefile
 src/fsharp/fsiAnyCpu/Makefile
 src/fsharp/policy.2.0.FSharp.Core/Makefile

--- a/src/fsharp/FSharp.Data.TypeProviders/Makefile.in
+++ b/src/fsharp/FSharp.Data.TypeProviders/Makefile.in
@@ -1,0 +1,51 @@
+NAME=FSharp.Data.TypeProviders
+ASSEMBLY = $(NAME).dll
+TOKEN=$(SIGN_TOKEN)
+
+srcdir := @abs_srcdir@/
+
+include @abs_top_builddir@/config.make
+
+FSC=$(protodir)fsc-proto.exe
+
+FLAGS += \
+	$(SIGN_FLAGS) \
+	--target:library \
+	--define:TPEMIT_INTERNAL_AND_MINIMAL_FOR_TYPE_CONTAINERS
+
+REFERENCES += \
+	-r:$(outdir)FSharp.Core.dll \
+	-r:System.Xml.dll \
+	-r:System.Configuration.dll \
+	-r:System.ServiceModel.dll \
+	-r:System.Xml.Linq.dll \
+	-r:System.Core.dll \
+	-r:System.Data.dll
+
+sources = \
+	$(tmpdir)FSData.fs \
+	../../assemblyinfo/assemblyinfo.FSharp.Data.TypeProviders.dll.fs \
+	Util.fsi Util.fs \
+	TypeProviderEmit.fsi TypeProviderEmit.fs \
+	TypeProvidersImpl.fs \
+	TypeProviders.fs
+
+RESOURCES= \
+	$(tmpdir)FSData.resources
+
+$(tmpdir)FSData.fs $(tmpdir)FSData.resources: FSData.txt
+	mono $(MONO_OPTIONS) $(FSSRGEN) $< $(tmpdir)FSData.fs $(tmpdir)FSData.resx
+	resgen $(tmpdir)FSData.resx $(tmpdir)FSData.resources
+
+
+include $(topdir)/src/fsharp/targets.make
+
+do-final: do-4-0 
+
+clean: clean-4-0
+
+install: install-lib-4 install-lib-4-5
+
+
+
+

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -19,6 +19,7 @@ do-final install:
 	$(MAKE) -C Fsc $@
 	$(MAKE) -C FSharp.Compiler.Interactive.Settings $@
 	$(MAKE) -C FSharp.Compiler.Server.Shared $@
+	$(MAKE) -C FSharp.Data.TypeProviders $@
 	$(MAKE) -C fsi $@
 	$(MAKE) -C fsiAnyCpu $@
 	$(MAKE) -C policy.2.0.FSharp.Core $@
@@ -36,6 +37,7 @@ clean clean-2-0 clean-4-0:
 	$(MAKE) -C Fsc $@
 	$(MAKE) -C FSharp.Compiler.Interactive.Settings $@
 	$(MAKE) -C FSharp.Compiler.Server.Shared $@
+	$(MAKE) -C FSharp.Data.TypeProviders $@
 	$(MAKE) -C fsi $@
 	$(MAKE) -C fsiAnyCpu $@
 	$(MAKE) -C policy.2.0.FSharp.Core $@


### PR DESCRIPTION
This adds the build of FSharp.Data.TypeProviders on Linux/Mac, see
https://github.com/fsharp/fsharp/issues/68

The DLL might not yet be much use on Linux and Mac ut this at least gets the 'make' build on Linux/Mac par with the 'msbuild' build on Windows
