### PR TITLE
use ClrRoot of current RuntimeEnvironment instead of hardcoded 4.0 on mono

### DIFF
--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -2437,11 +2437,9 @@ type TcConfig private (data : TcConfigBuilder,validate:bool) =
             []
 #else                    
             // When running on Mono we lead everyone to believe we're doing .NET 4.0 compilation 
-            // by default. 
+            // by default. Why? See https://github.com/fsharp/fsharp/issues/99
             if runningOnMono then 
-                let sysDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory() 
-                let mono40SysDir = Path.Combine(Path.GetDirectoryName sysDir, "4.0")
-                [mono40SysDir]
+                [System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()]
             else                                
                 try 
                     match tcConfig.resolutionEnvironment with


### PR DESCRIPTION
This commit should fix #99. 
It should be tested on old mono versions which do not support 4.5. This should work.
And somebody should figure out why the old code was hard-coded to use 4.0.
