### PR TITLE
Unicode letters & operators partially

### DIFF
--- a/src/fsharp/lex.fsl
+++ b/src/fsharp/lex.fsl
@@ -163,14 +163,14 @@ let extractIdentFromHashIf (lexed:string) =
     trimIf.Substring(0, identEnd)
 } 
 
-let letter = '\Lu' | '\Ll' | '\Lt' | '\Lm' | '\Lo' | '\Nl'
+let letter = '\Lu' | '\Ll' | '\Lt' | '\Lm' | '\Lo' | '\Nl' | '\So'
 let surrogateChar = '\Cs'
 let digit = '\Nd'
 let hex = ['0'-'9'] | ['A'-'F'] | ['a'-'f']
 let truewhite = [' ']
 let offwhite = ['\t']
 let anywhite = truewhite | offwhite
-let op_char = '!'|'$'|'%'|'&'|'*'|'+'|'-'|'.'|'/'|'<'|'='|'>'|'?'|'@'|'^'|'|'|'~'|':'
+let op_char = '!'|'$'|'%'|'&'|'*'|'+'|'-'|'.'|'/'|'<'|'='|'>'|'?'|'@'|'^'|'|'|'~'|':'|'\So'
 let ignored_op_char = '.' | '$' | '?'
 let xinteger = 
   (  '0' ('x'| 'X')  hex + 


### PR DESCRIPTION
related issue: https://github.com/fsharp/fsharp/issues/123

what works: 

``` fsharp
let ★ x = x + 5
let (|★) x y = x + y
let summ = ★ 5 |★ 5 // 15
```

``` fsharp
let © = "my copyright notes"
let project = "Heather"
let version = 1
let str = sprintf  "%s v.%d %s" project version ©
```

``` fsharp
let ⌨ msg = Clients.All.addMessage msg
```

what doesn't work (conflicts with letters but I don't know how to implement it for now):

``` fsharp
let (★) x y = x + y
let summ = 5 ★ 5
```
