### PR TITLE
configure: improve the prefix warning, and simplify some bits

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,11 +53,10 @@ AC_ARG_WITH([gacdir],
                 [with_gacdir=no]
         )
 
+MONOPREFIX=$(cd `$PKG_CONFIG --variable=prefix mono` && pwd)
+
 if test "x$with_gacdir" = "xno"; then
-	MONODIR=`$PKG_CONFIG --variable=libdir mono`/mono
-	if ! test -e $MONODIR/2.0/mscorlib.dll; then
-		MONODIR=`$PKG_CONFIG --variable=prefix mono`/lib/mono
-	fi
+	MONODIR="$MONOPREFIX"/lib/mono
 else
 	MONODIR=$(cd "$with_gacdir/.." && pwd)
 fi
@@ -104,10 +103,7 @@ src/fsharp/policy.4.3.FSharp.Core/Makefile
 ])
 AC_OUTPUT
 
-CANON_MONODIR=`cd $MONODIR/../..; pwd`
-
-if ! test -e $prefix/bin/mono; then
-	AC_WARN($prefix/bin/mono not found. Prefix should normally be set to the mono installation path. Consider using 
-   ./autogen.sh --prefix=$CANON_MONODIR
-)
+if ! test "x$MONOPREFIX" = "x$prefix"; then
+	AC_WARN([Prefix to use is not the same as mono's: $prefix
+		Consider using: ./autogen.sh --prefix=$MONOPREFIX])
 fi


### PR DESCRIPTION
It's better to compare prefixes than to check if $prefix/bin/mono binary
exists, because in the case of being inside a parallel mono environment[1],
it would warn the user about choosing /usr prefix if mono's prefix inside
this environment is not /usr (i.e.: /opt/mono).

Also, cleanup some variables:
- CANON_MONODIR not needed, as it's actually just Mono's prefix.
- No need to check both Mono's libdir and prefix via pkgconfig, as
  these two variables have been both there in Mono's PC file for years [2],
  and anyway the existance of $MONODIR/2.0/mscorlib.dll is checked later,
  just in case.

[1] http://www.mono-project.com/Parallel_Mono_Environments
[2] https://github.com/mono/mono/commits/master/data/mono.pc.in
