### PR TITLE
Use Control-D for quit

### DIFF
--- a/src/fsharp/fsi/console.fs
+++ b/src/fsharp/fsi/console.fs
@@ -444,11 +444,7 @@ type internal ReadLineConsole() =
                 change()
             // Control-d
             | (ConsoleModifiers.Control, '\004') ->
-                if (input.Length = 0) then
-                    raise <| new System.IO.EndOfStreamException()
-                else
-                    delete ();
-                    change()
+                exit 0 //quit
             | _ ->
                 // Note: If KeyChar=0, the not a proper char, e.g. it could be part of a multi key-press character,
                 //       e.g. e-acute is ' and e with the French (Belgium) IME and US Intl KB.


### PR DESCRIPTION
On linux / unix based systems, control-D inserts an EOF which should be
read as quitting.

Note: There was some code that I deleted here.  I think it might have used control-d as a second delete key, but this seems like the wrong thing to do - also, for an inexperienced linux user, doing

```
fsharpi
> <control-d>
```

will result in a pretty nasty crash at the moment which is probably not a good experience
