### PR TITLE
Fixed build.bat so it works correctly under paths containing a space

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -14,7 +14,7 @@ del /F /S /Q lib\release
 pushd .
 cd .\src
 set ABS_PATH=%CD%
-%MSBUILD% %ABS_PATH%/fsharp-proto-build.proj 
-%MSBUILD% %ABS_PATH%/fsharp-library-build.proj /p:TargetFramework=net40 /p:Configuration=Release
-%MSBUILD% %ABS_PATH%/fsharp-compiler-build.proj /p:TargetFramework=net40 /p:Configuration=Release
+%MSBUILD% "%ABS_PATH%\fsharp-proto-build.proj"
+%MSBUILD% "%ABS_PATH%\fsharp-library-build.proj" /p:TargetFramework=net40 /p:Configuration=Release
+%MSBUILD% "%ABS_PATH%\fsharp-compiler-build.proj" /p:TargetFramework=net40 /p:Configuration=Release
 popd


### PR DESCRIPTION
I tried to run build.bat today and it stopped immediately with an MSBuild error saying something about only being able to build one project at a time. I realized `build.bat` wasn't wrapping the filename in quotes before passing it to `msbuild`, which was being tripped up because the path contained a folder with spaces in the name.

I fixed `build.bat` so it quotes the filenames before passing them to `msbuild`, and it now it's able to run as expected.
