### PR TITLE
Ignore generated lexer/parser files for the Silverlight-based compiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ src/fsharp/FSharp.Compiler-proto/ilpars.fsi
 src/fsharp/FSharp.Compiler-proto/lex.fs
 src/fsharp/FSharp.Compiler-proto/pars.fs
 src/fsharp/FSharp.Compiler-proto/pars.fsi
+src/fsharp/FSharp.Compiler.Silverlight/lex.fs
+src/fsharp/FSharp.Compiler.Silverlight/pars.fs
+src/fsharp/FSharp.Compiler.Silverlight/pars.fsi
 *~
 tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.sln
 tests/projects/Sample_VS2012_FSharp_ConsoleApp_net45_with_resource/Sample_VS2012_FSharp_ConsoleApp_net45/Sample_VS2012_FSharp_ConsoleApp_net45.userprefs


### PR DESCRIPTION
Ignore the generated lexer/parser files for the Silverlight-based compiler so they won't be committed accidentally.
