### PR TITLE
install: avoid using DESTDIR in .Targets files

### DIFF
--- a/src/fsharp/targets.make
+++ b/src/fsharp/targets.make
@@ -158,7 +158,7 @@ install-lib-2 install-lib-2-1 install-lib-4:
 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Targets $(DESTDIR)$(gacdir)/$(TARGET)/; \
 	    mkdir -p $(tmpdir); \
 	    echo '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' > $(tmpdir)Microsoft.FSharp.Targets; \
-	    echo '    <Import Project="$(DESTDIR)$(gacdir)/$(TARGET)/Microsoft.FSharp.Targets" />' >> $(tmpdir)Microsoft.FSharp.Targets; \
+	    echo '    <Import Project="$(gacdir)/$(TARGET)/Microsoft.FSharp.Targets" />' >> $(tmpdir)Microsoft.FSharp.Targets; \
 	    echo '</Project>' >> $(tmpdir)Microsoft.FSharp.Targets; \
 	    mkdir -p $(DESTDIR)$(gacdir)/Microsoft\ F#/v$(TARGET)/; \
 	    mkdir -p $(DESTDIR)$(gacdir)/Microsoft\ SDKs/F#/3.0/Framework/v$(TARGET)/; \
@@ -175,7 +175,7 @@ install-lib-2 install-lib-2-1 install-lib-4:
 	@if test -e $(outdir)Microsoft.Portable.FSharp.Targets; then \
 	    $(INSTALL_LIB) $(outdir)Microsoft.Portable.FSharp.Targets $(DESTDIR)$(gacdir)/$(TARGET)/; \
 	    echo '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' > $(tmpdir)Microsoft.Portable.FSharp.Targets; \
-	    echo '    <Import Project="$(DESTDIR)$(gacdir)/$(TARGET)/Microsoft.Portable.FSharp.Targets" />' >> $(tmpdir)Microsoft.Portable.FSharp.Targets; \
+	    echo '    <Import Project="$(gacdir)/$(TARGET)/Microsoft.Portable.FSharp.Targets" />' >> $(tmpdir)Microsoft.Portable.FSharp.Targets; \
 		echo '</Project>' >> $(tmpdir)Microsoft.Portable.FSharp.Targets; \
 	    mkdir -p $(DESTDIR)$(gacdir)/Microsoft\ F#/v$(TARGET)/; \
 	    mkdir -p $(DESTDIR)$(gacdir)/Microsoft\ SDKs/F#/3.0/Framework/v$(TARGET)/; \


### PR DESCRIPTION
$DESTDIR is only meant to be a prefix to the prefix specified
by the user, at install time. That is, if the prefix specified
was /usr, and $DESTDIR is assigned the value /tmp when running
the target 'make install', then all the files installed should
be in /tmp/usr, but their contents should never reference this
temporal path /tmp/usr, but /usr, because DESTDIR is only
meant to be used as a hook to where leave the binaries generated
for a certain prefix.

Fixes github issue #204, reported by Henrik Feldt.
