### PR TITLE
Bootstrapping F# 3.1 on a clean Mono does not work

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -58,7 +58,7 @@ SIGN_TOKEN = f536804aa0eb945b
 bootstrapdir = $(bootstrap)/4.0/
 tmpdir = .libs/$(CONFIG)/
 objdir = $(tmpdir)$(TARGET)/
-protodir = $(builddir)/lib/proto
+protodir = $(builddir)/lib/proto/
 outdir = $(builddir)lib/$(CONFIG)/$(outsuffix)/
 
 INSTALL = $(SHELL) $(topdir)install-sh

--- a/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
+++ b/src/fsharp/FSharp.Compiler-proto/FSharp.Compiler-proto.fsproj
@@ -422,7 +422,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="Fsharp.Core" />
+    <Reference Include="FSharp.Core" />
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />

--- a/src/fsharp/Fsc-proto/Makefile.in
+++ b/src/fsharp/Fsc-proto/Makefile.in
@@ -5,12 +5,8 @@ srcdir := @abs_srcdir@/
 
 include @abs_top_builddir@/config.make
 
-build-proto: $(protodir)FSharp.Core.dll
+build-proto:
 	MONO_ENV_OPTIONS=$(monoopts) xbuild /p:Configuration=Proto
+	chmod +x $(protodir)fsc-proto.exe
 
 include $(topdir)/src/fsharp/targets.make
-
-# We need the bootstrap's FSharp.Core to run the proto
-$(protodir)FSharp.Core.dll: $(bootstrapdir)FSharp.Core.dll
-	@-mkdir $(protodir)
-	cp -p $(bootstrapdir)FSharp.Core.dll $(protodir)FSharp.Core.dll

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -1,3 +1,6 @@
+srcdir := @abs_srcdir@/
+
+include @abs_top_builddir@/config.make
 
 # Make the proto using the bootstrap, then make the final compiler using the proto
 # We call MAKE sequentially because we don't want build-final to explicitly depend on build-proto,
@@ -7,7 +10,12 @@ all:
 	$(MAKE) build-proto
 	$(MAKE) build
 
-build-proto:
+# We need the bootstrap's FSharp.Core to run the proto
+build-proto: $(bootstrapdir)FSharp.Core.dll $(bootstrapdir)FSharp.Core.sigdata $(bootstrapdir)FSharp.Core.optdata
+	@-mkdir $(protodir)
+	cp -p $(bootstrapdir)FSharp.Core.dll $(protodir)FSharp.Core.dll
+	cp -p $(bootstrapdir)FSharp.Core.sigdata $(protodir)FSharp.Core.sigdata
+	cp -p $(bootstrapdir)FSharp.Core.optdata $(protodir)FSharp.Core.optdata
 	$(MAKE) -C FSharp.Build-proto Configuration=proto $@
 	$(MAKE) -C FSharp.Compiler-proto Configuration=proto $@
 	$(MAKE) -C Fsc-proto Configuration=proto $@


### PR DESCRIPTION
Bootstrapping on Mono results in various errors and warnings:
1. The reference for the F# library is FSharp.Core, not Fsharp.Core
2. protodir must end with a '/', otherwise FSharp.Core.dll will be
   copied to protoFSharp.Core.dll (which will not be found later on)
3. sigdata and optdata should be copied when copying FSharp.Core.dll
4. fsc-proto must be marked executable, otherwise xbuild will refuse
   to run it
5. FSharp.Core is only needed to run fsc-proto, but placing it in the
   correct directory before any of the build-proto steps silences
   quite a few warnings about the missing "FSharp.Core reference"
