### PR TITLE
Proposed test improvement: add test seq.GetEnumerator

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.Unittests.fsproj
@@ -81,6 +81,7 @@
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SetType.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SeqModule.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SeqModule2.fs" />
+    <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\SeqType.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Collections\StringModule.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Core\BigIntType.fs" />
     <Compile Include="FSharp.Core\Microsoft.FSharp.Core\IntConversions.fs" />

--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/SeqType.fs
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core/Microsoft.FSharp.Collections/SeqType.fs
@@ -1,0 +1,79 @@
+﻿
+// Various tests for the:
+// Microsoft.FSharp.Collections.seq type
+
+namespace FSharp.Core.Unittests.FSharp_Core.Microsoft_FSharp_Collections
+
+open System
+open System.Collections
+open System.Collections.Generic
+open FSharp.Core.Unittests.LibraryTestFx
+open NUnit.Framework
+
+
+[<TestFixture>]
+type SeqType() =
+    
+    // Interfaces
+    [<Test>]
+    member this.IEnumerable() =
+        
+        // Legit IE
+        let ie = seq { yield 1; yield 2; yield 3 } :> IEnumerable
+        let enum = ie.GetEnumerator()
+        
+        let testStepping() =
+            CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+            Assert.AreEqual(true, enum.MoveNext())
+            Assert.AreEqual(1, enum.Current)
+            Assert.AreEqual(true, enum.MoveNext())
+            Assert.AreEqual(2, enum.Current)
+            Assert.AreEqual(true, enum.MoveNext())
+            Assert.AreEqual(3, enum.Current)
+            Assert.AreEqual(false, enum.MoveNext())
+            CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+    
+        CheckThrowsNotSupportedException(fun () -> enum.Reset() |> ignore)
+        testStepping()
+        CheckThrowsNotSupportedException(fun () -> enum.Reset() |> ignore)
+    
+        // Empty IE
+        let ie = Seq.empty :> IEnumerable  // Note no type args
+        let enum = ie.GetEnumerator()
+        
+        CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+        Assert.AreEqual(false, enum.MoveNext())
+        CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+        CheckThrowsNotSupportedException(fun () -> enum.Reset() |> ignore)
+
+    [<Test>]
+    member this.IEnumerable_T() =
+        
+        // Legit IE
+        let ie = seq { yield 'a'; yield 'b'; yield 'c'}
+        let enum = ie.GetEnumerator()
+        
+        let testStepping() =
+            CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+            Assert.AreEqual(true,   enum.MoveNext())
+            Assert.AreEqual('a',    enum.Current)
+            Assert.AreEqual(true,   enum.MoveNext())
+            Assert.AreEqual('b',    enum.Current)
+            Assert.AreEqual(true,   enum.MoveNext())
+            Assert.AreEqual('c',    enum.Current)
+            Assert.AreEqual(false, enum.MoveNext())
+            CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+        
+        CheckThrowsNotSupportedException(fun () -> enum.Reset() |> ignore)
+        testStepping()
+        CheckThrowsNotSupportedException(fun () -> enum.Reset() |> ignore)
+    
+        // Empty IE
+        let ie = Seq.empty :> IEnumerable<int>  // Note no type args
+        let enum = ie.GetEnumerator()
+        
+        CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+        Assert.AreEqual(false, enum.MoveNext())
+        CheckThrowsInvalidOperationExn(fun () -> enum.Current |> ignore)
+        CheckThrowsNotSupportedException(fun () -> enum.Reset() |> ignore)
+


### PR DESCRIPTION
seq expressions dont generate check for access of Enumerator.Current before call to Enumerator.MoveNext()

``` F#
> ( seq { yield 1; yield 2; } ).GetEnumerator().Current;;
val it : int = 0
```

``` F#
> ( seq { for i in 1 .. 10 do yield i } ).GetEnumerator().Current;;
val it : int = 0
```

with range is ok:

``` F#
> ( seq { 1 .. 10 } ).GetEnumerator().Current;;
System.InvalidOperationException: Enumeration has not started. Call MoveNext.
```

this pr add test for IEnumerable and IEnumerable< ' T > similar to ListType IEnumerable.
Enumerator.Reset() is not supported for sequence.
