### PR TITLE
Proposed library improvement: raise a NotFiniteNumberException instead of an Exception

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -960,7 +960,7 @@ namespace Microsoft.FSharp.Core
                 abstract CompareC : obj * obj -> int   // implemented further below
                 member  c.ThrowsOnPER() = throwsOnPER
 
-            let NaNException = new System.Exception()                                                 
+            let NaNException = new System.NotFiniteNumberException()
                     
             let rec GenericCompare (comp:GenericComparer) (xobj:obj,yobj:obj) = 
                 (*if objEq xobj yobj then 0 else *)


### PR DESCRIPTION
It makes sense to me that wherever FSharp.Core is raising an exception due to a NaN value, it should raise the more-specific `NotFiniteNumberException` instead of a basic `Exception`. Otherwise, the user and developer have essentially zero information about why the exception was raised, since the raised exception currently does not include an error message.
