### PR TITLE
Proposed perf improvement for the 'dict' operator

### DIFF
--- a/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/fsharp/FSharp.Core/fslib-extra-pervasives.fs
@@ -39,13 +39,8 @@ module ExtraTopLevelOperators =
     [<CompiledName("CreateSet")>]
     let set l = Collections.Set.ofSeq l
 
-    [<CompiledName("CreateDictionary")>]
-    let dict l = 
-        // Use a dictionary (this requires hashing and equality on the key type)
-        // Wrap keys in a StructBox in case they are null (when System.Collections.Generic.Dictionary fails). 
-        let t = new Dictionary<RuntimeHelpers.StructBox<'Key>,_>(RuntimeHelpers.StructBox<'Key>.Comparer)
-        for (k,v) in l do 
-            t.[RuntimeHelpers.StructBox(k)] <- v
+    /// Creates a read-only wrapper around a mutable dictionary.
+    let private readOnlyDict (t : Dictionary<_,_>) : IDictionary<_,_> =
         let d = (t :> IDictionary<_,_>)
         let c = (t :> ICollection<_>)
         // Give a read-only view of the dictionary
@@ -75,9 +70,13 @@ module ExtraTopLevelOperators =
                 member s.Values = d.Values
                 member s.Add(k,v) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
                 member s.ContainsKey(k) = d.ContainsKey(RuntimeHelpers.StructBox(k))
-                member s.TryGetValue(k,r) = 
-                    let key = RuntimeHelpers.StructBox(k)
-                    if d.ContainsKey(key) then (r <- d.[key]; true) else false
+                member s.TryGetValue(k,r) =  
+                    match d.TryGetValue (RuntimeHelpers.StructBox(k)) with
+                    | true, v ->
+                        r <- v
+                        true
+                    | false, _ ->
+                        false
                 member s.Remove(k : 'Key) = (raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated))) : bool) 
           interface ICollection<KeyValuePair<'Key, 'T>> with 
                 member s.Add(x) = raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)));
@@ -98,6 +97,75 @@ module ExtraTopLevelOperators =
                 member s.GetEnumerator() = 
                     ((c |> Seq.map (fun (KeyValue(k,v)) -> KeyValuePair<_,_>(k.Value,v))) :> System.Collections.IEnumerable).GetEnumerator() }
 
+    /// An empty, read-only dictionary.
+    /// This field is used to avoid (potentially) creating multiple empty dictionary instances;
+    /// having only one empty dictionary instance helps make better use of structure-sharing.
+    let private emptyDict<'Key, 'Value when 'Key : equality> =
+        readOnlyDict <| Dictionary<RuntimeHelpers.StructBox<'Key>, 'Value> (0, RuntimeHelpers.StructBox<'Key>.Comparer)
+
+    [<CompiledName("CreateDictionary")>]
+    let dict (keyValuePairs : seq<'Key * 'Value>) =
+        checkNonNullNullArg "keyValuePairs" keyValuePairs
+
+        // Use a dictionary (this requires hashing and equality on the key type)
+        // Wrap keys in a StructBox in case they are null (when System.Collections.Generic.Dictionary fails).
+        // Try to use an optimized implementation based on the input type.
+        match keyValuePairs with
+        | :? (('Key * 'Value)[]) as kvpArray ->
+            match kvpArray.Length with
+            | 0 -> emptyDict
+            | len ->
+                let t = Dictionary<RuntimeHelpers.StructBox<'Key>,_>(kvpArray.Length, RuntimeHelpers.StructBox<'Key>.Comparer)
+
+                for i = 0 to len - 1 do
+                    let k, v = kvpArray.[i]
+                    t.[RuntimeHelpers.StructBox(k)] <- v
+                readOnlyDict t
+
+        | :? (('Key * 'Value) list) as kvpList ->
+            if kvpList.IsEmpty then
+                emptyDict
+            else
+                // List.count is O(n)! However, it should still be faster than (potentially) resizing the dictionary.
+                let t = Dictionary<RuntimeHelpers.StructBox<'Key>,_>(kvpList.Length, RuntimeHelpers.StructBox<'Key>.Comparer)
+
+                let mutable kvpList = kvpList
+                while not kvpList.IsEmpty do
+                    let k, v = kvpList.Head
+                    t.[RuntimeHelpers.StructBox(k)] <- v
+                    kvpList <- kvpList.Tail
+                readOnlyDict t
+
+        | :? IList<'Key * 'Value> as kvpList ->
+            match kvpList.Count with
+            | 0 -> emptyDict
+            | len ->
+                let t = Dictionary<RuntimeHelpers.StructBox<'Key>,_>(kvpList.Count, RuntimeHelpers.StructBox<'Key>.Comparer)
+
+                for i = 0 to len - 1 do
+                    let k, v = kvpList.[i]
+                    t.[RuntimeHelpers.StructBox(k)] <- v
+                readOnlyDict t
+
+        | :? ICollection<'Key * 'Value> as kvpColl ->
+            match kvpColl.Count with
+            | 0 -> emptyDict
+            | count ->
+                let t = Dictionary<RuntimeHelpers.StructBox<'Key>,_>(count, RuntimeHelpers.StructBox<'Key>.Comparer)
+                for (k,v) in keyValuePairs do 
+                    t.[RuntimeHelpers.StructBox(k)] <- v
+                readOnlyDict t
+
+        | _ ->
+            let t = Dictionary<RuntimeHelpers.StructBox<'Key>,_>(RuntimeHelpers.StructBox<'Key>.Comparer)
+            for (k,v) in keyValuePairs do 
+                t.[RuntimeHelpers.StructBox(k)] <- v
+            
+            // If the created dictionary is empty (because the input sequence was empty), return 'emptyDict';
+            // this avoids the need to use Seq.isEmpty (which can cause problems if it has to partially or wholly
+            // evaluate the sequence just to determine if it's empty, then evaluate again to create the dictionary).
+            if t.Count = 0 then emptyDict
+            else readOnlyDict t
 
     let getArray (vals : seq<'T>) = 
         match vals with


### PR DESCRIPTION
I've optimized the implementation of the `dict` operator so it checks the type of the input sequence and uses an optimized codepath (if possible) when building the underlying mutable dictionary. These optimized codepaths are able to iterate over the input data more efficiently; importantly, for some input data types (e.g., an array) where it is fast and easy to determine the count/length of the sequence, it allows the underlying dictionary to be initialized to the exact capacity needed -- which avoids unnecessarily resizing the dictionary while adding the data.

Additionally, I've modified the implementation of the `IDictionary<_,_>.TryGetValue()` method in the object expression which creates the immutable dictionary implementation. The original version calls `.ContainsKey()` then separately retrieves the value if found; now, it uses `.TryGetValue()` on the underlying mutable dictionary to accomplish the same thing with just one lookup.
