### PR TITLE
add travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ On OSX, requires automake 2.69. To install from [homebrew](http://mxcl.github.co
 brew install automake
 ```
 
+## Build status
+
+Mono 3.x [![Build Status](https://travis-ci.org/enricosada/fsharp.png?branch=fsharp_31)](https://travis-ci.org/fsharp/fsharp)
 
 ## Building
 


### PR DESCRIPTION
add travis build status badge on README.

now the badge is linked to my repo for preview, should be changed to https://travis-ci.org/fsharp/fsharp.png?branch=fsharp_31 before merge

?branch=fsharp_31 mean check only build status of branch fsharp_31 not others ( like master or feature branch without .travis.yml -> failing )
