### PR TITLE
Added portable support for FSharp.Core

### DIFF
--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -205,9 +205,8 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>
     <DefineConstants>$(DefineConstants);DONT_INCLUDE_DEPRECATED</DefineConstants>
     <DefineConstants>$(DefineConstants);PUT_TYPE_PROVIDERS_IN_FSCORE</DefineConstants>
-
-    <AssemblySearchPaths>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.0\Profile\$(TargetFrameworkProfile)</AssemblySearchPaths>    
-    <OtherFlags>$(OtherFlags) --simpleresolution -r:"$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.0\Profile\$(TargetFrameworkProfile)\mscorlib.dll" -r:"$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.0\Profile\$(TargetFrameworkProfile)\System.dll" -r:"$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.0\Profile\$(TargetFrameworkProfile)\System.Core.dll"</OtherFlags>
+    <AssemblySearchPaths>$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.0\Profile\$(TargetFrameworkProfile)</AssemblySearchPaths>    
+    <OtherFlags>$(OtherFlags) --simpleresolution</OtherFlags>
 
   </PropertyGroup>
 
@@ -678,9 +677,22 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
 
   <!-- Include the portable targets file when building the portable FSharp.Core -->
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets"
-          Condition="'$(TargetFramework)'=='portable-net4+sl4+wp71+win8'"/>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets"
-          Condition="'$(TargetFramework)'=='portable-net45+sl5+win8'"/>
+          Condition=" '$(TargetFramework)'=='portable-net45+sl5+win8' OR '$(TargetFramework)'=='portable-net4+sl4+wp71+win8' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')" />
+  
+  <!-- If the Microsoft.Portable.Common.targets file does not exist when building the portable FSharp.Core, include the following ProperyGroup -->
+  <PropertyGroup Condition=" '$(TargetFramework)'=='portable-net45+sl5+win8' OR '$(TargetFramework)'=='portable-net4+sl4+wp71+win8' AND !Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')">
+
+    <AvailablePlatforms>Any CPU</AvailablePlatforms>
+
+    <TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
+
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <NoStdLib>true</NoStdLib>
+
+    <ImplicitlyExpandTargetFramework Condition="'$(ImplicitlyExpandTargetFramework)' == '' ">true</ImplicitlyExpandTargetFramework> 
+  </PropertyGroup>
 
   <!-- Include the bootstrap targets file when building the proto compiler using the bootstrap -->
   <!-- Also include it if Proto targets file doesn't exist, e.g. when cleaning the build with /t:Clean -->


### PR DESCRIPTION
Although I have included Profile88 in the import and PropertyGroup
section it wont build on mono as this profile is not supported.

Only profiles 5,6,14,19,24,37,42,47,136,147,158 for .Net 4.0 and
7,49,78 for .Net 4.5
