### PR TITLE
Make fsi aware of what it is called

### DIFF
--- a/launcher.in
+++ b/launcher.in
@@ -27,4 +27,4 @@ fi
 # location of the default FSharp install in order to find the FSharp compiler binaries (see 
 # fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerLocationUtils.fs). That's a pretty unfortunate
 # way of finding those binaries. And really should be changed.
-$EXEC mono $DEBUG $MONO_OPTIONS $MONO_GC_OPTIONS @DIR@/@TOOL@ "$@"
+$EXEC mono $DEBUG $MONO_OPTIONS $MONO_GC_OPTIONS @DIR@/@TOOL@ --exename:$(basename $0) "$@"

--- a/src/fsharp/build.fs
+++ b/src/fsharp/build.fs
@@ -1965,6 +1965,8 @@ type TcConfigBuilder =
 
       /// if true - every expression in quotations will be augmented with full debug info (filename, location in file)
       mutable emitDebugInfoInQuotations : bool
+
+      mutable exename : string option
       }
 
 
@@ -2109,6 +2111,7 @@ type TcConfigBuilder =
           sqmNumOfSourceFiles = 0
           sqmSessionStartedTime = System.DateTime.Now.Ticks
           emitDebugInfoInQuotations = false
+          exename = None
         }
 
     member tcConfigB.ResolveSourceFile(m,nm,pathLoadedFrom) = 

--- a/src/fsharp/build.fsi
+++ b/src/fsharp/build.fsi
@@ -317,7 +317,8 @@ type TcConfigBuilder =
       mutable sqmSessionGuid : System.Guid option
       mutable sqmNumOfSourceFiles : int
       sqmSessionStartedTime : int64
-      mutable emitDebugInfoInQuotations : bool }
+      mutable emitDebugInfoInQuotations : bool
+      mutable exename : string option }
 
     static member CreateNew : 
         defaultFSharpBinariesDir: string * 

--- a/src/fsharp/fscopts.fs
+++ b/src/fsharp/fscopts.fs
@@ -461,6 +461,7 @@ let vsSpecificFlags (tcConfigB: TcConfigBuilder) =
     CompilerOption("flaterrors", tagNone, OptionUnit (fun () -> tcConfigB.flatErrors <- true), None, None); 
     CompilerOption("sqmsessionguid", tagNone, OptionString (fun s -> tcConfigB.sqmSessionGuid <- try System.Guid(s) |> Some  with e -> None), None, None);
     CompilerOption("gccerrors", tagNone, OptionUnit (fun () -> tcConfigB.errorStyle <- ErrorStyle.GccErrors), None, None); 
+    CompilerOption("exename", tagNone, OptionString (fun s -> tcConfigB.exename <- Some(s)), None, None);
     CompilerOption("maxerrors", tagInt, OptionInt (fun n -> tcConfigB.maxErrors <- n), None, None); ]
 
 

--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -479,8 +479,10 @@ type internal FsiCommandLineOptions(argv: string[], tcConfigB, fsiConsoleOutput:
 #if SILVERLIGHT
             "fsi.exe"
 #else
-            let currentProcess = System.Diagnostics.Process.GetCurrentProcess()
-            Path.GetFileName(currentProcess.MainModule.FileName)
+            match tcConfigB.exename with
+            |Some(s) -> s
+            |None -> let currentProcess = System.Diagnostics.Process.GetCurrentProcess()
+                     Path.GetFileName(currentProcess.MainModule.FileName)
 #endif
 
 


### PR DESCRIPTION
On mono fsi/fsc are called through fsharpi/fsharpc using `exec`.  As a
result, fsi doesn't know it is really called fsharpi.  This produced a
weird error message in `#help`.  This patch adds an `exename` parameter
to specify the command that was actually input to run fsi, making the
error messages make sense.

This is for github issue #227
