### PR TITLE
Fix formatting of Wheezy build section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Uses bootstrapping libraries, tools and F# compiler. The `lib/bootstrap/X.0` dir
 
 ### Wheezy build
 
+```
 vagrant up
 vagrant ssh
 cd /vagrant
@@ -278,7 +279,7 @@ sudo apt-get install dos2unix autoconf
 ./autogen.sh --prefix=/usr
 make
 sudo make install
-
+```
 
 [teamcity mono icon]: http://teamcity.codebetter.com/app/rest/builds/buildType:(id:bt814)/statusIcon
 [teamcity mono url]: http://teamcity.codebetter.com/viewType.html?buildTypeId=bt814&guest=1


### PR DESCRIPTION
The section was rendered as plain text, which eliminated the newlines and made it difficult to follow. I've added literal marks so it reads as a series of commands to execute.
