### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,6 @@ hello.exe
 
 F# compiler sources dropped by Microsoft are available from [fsharppowerpack.codeplex.com](http://fsharppowerpack.codeplex.com).
 
-Uses bootstrapping libraries, tools and F# compiler. The `lib/bootstrap/X.0` directories contain mono-built libraries, compiler and tools that can be used to bootstrap a build. You can also supply your own via the `--with-bootstrap` option.
-
 
 ### Wheezy build
 


### PR DESCRIPTION
There was some text here about bootstrapping that maybe belonged earlier, but certainly didn't belong in the history section.
