### PR TITLE
Simplify build by removing GC tweaking logic

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -21,9 +21,6 @@ gacdir := ${libdir}mono
 
 tooldir := $(topdir)lib/bootstrap/4.0/
 
-monoopts = @mono_gc_options@
-MONO_OPTIONS += @mono_gc_options@
-
 TargetFramework = net40
 CONFIG = release
 Configuration = Release

--- a/configure.ac
+++ b/configure.ac
@@ -24,13 +24,8 @@ if ! $PKG_CONFIG --atleast-version=$MONO_REQUIRED_VERSION mono; then
 	AC_MSG_ERROR("You need mono $MONO_REQUIRED_VERSION")
 fi
 
-AC_PATH_PROG(MONO_SGEN, mono-sgen, no)
-
 if ! $PKG_CONFIG --atleast-version=$MONO_RECOMMENDED_VERSION mono; then
 	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, for better MSBuild (xbuild) compatibility])
-
-	# stability of Mono's SGEN GC is not so good in older versions than Mono v3.0
-	MONO_SGEN=no
 fi
 
 # Checks for libraries.
@@ -74,15 +69,6 @@ AC_SUBST(MONOGACDIR)
 AC_SUBST(MONOGACDIR20)
 AC_SUBST(MONOGACDIR35)
 AC_SUBST(MONOGACDIR40)
-
-if test "x$MONO_SGEN" = "xno"; then
-	mono_gc_options=
-else
-	mono_gc_options=--gc=sgen
-fi
-
-AC_SUBST(mono_gc_options)
-
 
 AC_CONFIG_FILES([
 launcher

--- a/launcher.in
+++ b/launcher.in
@@ -16,15 +16,9 @@ if test x"$1" = x--valgrind; then
   EXEC="valgrind $VALGRIND_OPTIONS"   
 fi
 
-MONO_GC_OPTIONS=@mono_gc_options@
-if test x"$1" = x--gc=boehm; then
-  shift
-  MONO_GC_OPTIONS=--gc=boehm   
-fi
-
 # Beware this line must match the regular expression " (\/.*)\/fsi\.exe" when @TOOL@ is fsi.exe.
 # That's because the FSharp MonoDevelop addin looks inside the text of this script to determine the installation
 # location of the default FSharp install in order to find the FSharp compiler binaries (see 
 # fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerLocationUtils.fs). That's a pretty unfortunate
 # way of finding those binaries. And really should be changed.
-$EXEC mono $DEBUG $MONO_OPTIONS $MONO_GC_OPTIONS @DIR@/@TOOL@ --exename:$(basename $0) "$@"
+$EXEC mono $DEBUG $MONO_OPTIONS @DIR@/@TOOL@ --exename:$(basename $0) "$@"


### PR DESCRIPTION
Mono 3.0.x was the first version when Mono's SGEN GC could be
considered stable, and F# was using it by default for this
version.

But then Mono 3.2.0 was released, which defaults to SGEN GC
anyway, so there's no need to tweak F# build or scripts anymore,
as we can simplify all this by just making F# use what the
underlying mono uses as default.

If some user is interested in using SGEN GC, she should just
make sure that she's using Mono 3.2.x or higher, or just adjust
MONO_ENV_OPTIONS env var herself.
