### PR TITLE
Added portable support for FSharp.Core

### DIFF
--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -708,8 +708,8 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
                       Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')" />
 
   <!-- If the Microsoft.Portable.Common.targets file does not exist when building the portable FSharp.Core, include the following ProperyGroup -->
- <PropertyGroup Condition=" '$(TargetFramework)'=='portable-net45+sl5+win8' OR 
-                            '$(TargetFramework)'=='portable-net4+sl4+wp71+win8' AND 
+ <PropertyGroup Condition=" ('$(TargetFramework)'=='portable-net45+sl5+win8' OR 
+                             '$(TargetFramework)'=='portable-net4+sl4+wp71+win8') AND 
                             !Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')">
    <AvailablePlatforms>Any CPU</AvailablePlatforms>
    <TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>


### PR DESCRIPTION
Although I have included Profile88 in the import and PropertyGroup
section it wont build on mono as this profile is not supported.

Only profiles 5,6,14,19,24,37,42,47,136,147,158 for .Net 4.0 and
7,49,78 for .Net 4.5
