### PR TITLE
source index pdb files using SourceLink

### DIFF
--- a/sourcelink.cmd
+++ b/sourcelink.cmd
@@ -1,0 +1,8 @@
+@echo off
+if not exist packages\FAKE\tools\Fake.exe ( 
+  nuget.exe install FAKE -OutputDirectory packages -ExcludeVersion 
+)
+if not exist packages\SourceLink.Fake\tools\Fake.fsx ( 
+  nuget.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion
+)
+packages\FAKE\tools\FAKE.exe sourcelink.fsx %*

--- a/sourcelink.fsx
+++ b/sourcelink.fsx
@@ -1,0 +1,46 @@
+#r "packages/FAKE/tools/FakeLib.dll"
+#load "packages/SourceLink.Fake/tools/SourceLink.fsx"
+
+open System
+open System.IO
+open Fake
+open Fake.AssemblyInfoFile
+open SourceLink
+
+Target "SourceLink" (fun _ ->
+    use repo = new GitRepo(__SOURCE_DIRECTORY__)
+    !! "lib/release/*.pdb" 
+    |> Seq.iter (fun pdb ->
+        let nm = Path.GetFileNameWithoutExtension pdb
+        let proj = VsProj.LoadRelease (sprintf @"src\fsharp\%s\%s.fsproj" nm nm)
+        logfn "source linking %s" pdb
+        let compiles = proj.Compiles.SetBaseDirectory __SOURCE_DIRECTORY__
+        let gitFiles =
+            compiles
+            -- "src/assemblyinfo/assemblyinfo*.fs" // not source indexed
+            // generated and in fsproj as Compile, but in .gitignore, not source indexed
+            -- "src/fsharp/FSharp.Compiler/illex.fs" // <FsLex Include="..\..\absil\illex.fsl">
+            -- "src/fsharp/FSharp.Compiler/ilpars.fs"
+            -- "src/fsharp/FSharp.Compiler/lex.fs"
+            -- "src/fsharp/FSharp.Compiler/pars.fs"
+        repo.VerifyChecksums gitFiles
+        let pdbFiles =
+            compiles // generated, not in the fsproj as Compile, not source indexed
+            ++ "src/fsharp/fscmain.fs" //<FsSrGen Include="FSBuild.txt">
+            ++ "src/fsharp/fsharp.build/obj/release/fsbuild.fs"
+            ++ "src/fsharp/fsharp.compiler.interactive.settings/obj/release/fsinteractivesettings.fs"
+            ++ "src/absil/illex.fsl"
+            ++ "src/absil/ilpars.fsy"
+            ++ "src/fsharp/fsharp.compiler/obj/release/fscomp.fs"
+            ++ "src/fsharp/lex.fsl"
+            ++ "src/fsharp/pars.fsy"
+            ++ "src/fsharp/fsharp.compiler.server.shared/obj/release/fsservershared.fs"
+            ++ "src/fsharp/fsharp.data.typeproviders/obj/release/fsdata.fs"
+            ++ "src/fsharp/fsi/obj/release/fsistrings.fs"
+        proj.VerifyPdbChecksums pdbFiles
+        proj.CreateSrcSrv "https://raw.github.com/fsharp/fsharp/{0}/%var2%" repo.Revision (repo.Paths gitFiles)
+        Pdbstr.exec pdb proj.OutputFilePdbSrcSrv
+    )
+)
+
+RunTargetOrDefault "SourceLink"


### PR DESCRIPTION
This will source index all pdb files in fsharp\lib\release. Any generated files are not source indexed. You must clone the repository with core.autocrlf set to input so that the line endings match.

```
git clone -config core.autocrlf=input https://github.com/fsharp/FSharp.git
.\build.bat
.\sourcelink.cmd
```

![image](https://f.cloud.github.com/assets/80104/2122633/24a73aa8-9216-11e3-9f6c-c0b4e53e6036.png)

![image](https://f.cloud.github.com/assets/80104/2122635/29150d5e-9216-11e3-9f5d-41fd0b765ed6.png)
