### PR TITLE
configure: stop allowing Mono 2.9, recommend Mono 3.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,15 +17,15 @@ elif test "x$PKG_CONFIG" = "xno"; then
         AC_MSG_ERROR([You need to install pkg-config])
 fi
 
-MONO_REQUIRED_VERSION=2.9
-MONO_RECOMMENDED_VERSION=3.0
+MONO_REQUIRED_VERSION=3.0
+MONO_RECOMMENDED_VERSION=3.2
 
 if ! $PKG_CONFIG --atleast-version=$MONO_REQUIRED_VERSION mono; then
 	AC_MSG_ERROR("You need mono $MONO_REQUIRED_VERSION")
 fi
 
 if ! $PKG_CONFIG --atleast-version=$MONO_RECOMMENDED_VERSION mono; then
-	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, for better MSBuild (xbuild) compatibility])
+	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, for better GC performance])
 fi
 
 # Checks for libraries.


### PR DESCRIPTION
F# 3.1 build is xbuild-based, so configure needs to check that
Mono 3.0 (or newer) is in place, not 2.9 (this old version
had limitations that prevented F# projects to build with xbuild).

We take advantage of this opportunity to re-use the AC_MSG_WARN
that recommends a mono version, to advice about using Mono 3.2
(instead of 3.0) as it defaults to SGen GC.

(Should fix #264)
