### PR TITLE
add diagnostics message to autogen.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,9 @@ elif test "x$PKG_CONFIG" = "xno"; then
         AC_MSG_ERROR([You need to install pkg-config])
 fi
 
+AC_MSG_NOTICE("pkg-config: $PKG_CONFIG")
+AC_MSG_NOTICE("PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR")
+
 MONO_REQUIRED_VERSION=3.0
 MONO_RECOMMENDED_VERSION=3.2
 


### PR DESCRIPTION
trying to build from sources on mac osx i found these useful:
- pkg-config, can be in different location
- PKG_CONFIG_LIBDIR, if doesn't contain the mono.pc directory, configure fails

but mostly thx to sshaw, drwhom and S11001001 of the #fsharp irc chan
