### PR TITLE
Update Microsoft.Portable.FSharp.Targets

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.Portable.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.Portable.FSharp.Targets
@@ -72,9 +72,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 	</PropertyGroup>
 
 	<Target Name="ImplicitlyExpandTargetFramework"
-		DependsOnTargets="$(ImplicitlyExpandTargetFrameworkDependsOn)"
-                Condition="!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets') AND
-                           !Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.props')" >
+		DependsOnTargets="$(ImplicitlyExpandTargetFrameworkDependsOn)">
 
 		<ItemGroup>
 			<ReferenceAssemblyPaths Include="$(_TargetFrameworkDirectories)"/>


### PR DESCRIPTION
This should fix the Mono 3.2.7 work around section, currently the condition statements conflict causing an error, see: https://github.com/fsharp/fsharp/issues/299#issuecomment-39466891
