### PR TITLE
Do not add FSharp.Build.dll to the GAC

### DIFF
--- a/src/fsharp/targets.make
+++ b/src/fsharp/targets.make
@@ -33,7 +33,6 @@ install-lib:
 	    echo "Signing $(outdir)$(ASSEMBLY) with Mono key"; \
 	    sn -q -R $(outdir)$(ASSEMBLY) $(srcdir)../../../mono.snk; \
 	fi
-	gacutil -i $(outdir)$(ASSEMBLY) -root $(DESTDIR)$(libdir) -package $(TARGET)
 	@if test x-$(NAME) = x-FSharp.Build; then \
 	    echo "Installing Microsoft.FSharp.Targets and Microsoft.Portable.FSharp.Targets into install locations matching Visual Studio"; \
 	    echo " --> $(DESTDIR)$(gacdir)/$(TARGET)/"; \
@@ -70,10 +69,16 @@ install-lib:
 	    $(INSTALL_LIB) $(tmpdir)Microsoft.Portable.FSharp.Targets $(DESTDIR)$(gacdir)/Microsoft\ SDKs/F#/3.1/Framework/v$(TARGET)/; \
 	    $(INSTALL_LIB) $(tmpdir)Microsoft.Portable.FSharp.Targets $(DESTDIR)$(gacdir)/xbuild/Microsoft/VisualStudio/v/FSharp/; \
 	    $(INSTALL_LIB) $(tmpdir)Microsoft.Portable.FSharp.Targets $(DESTDIR)$(gacdir)/xbuild/Microsoft/VisualStudio/v12.0/FSharp/; \
-	fi
-	@if test -e $(outdir)$(NAME).xml; then \
+	    \
+	    echo $(INSTALL_LIB) $(outdir)$(ASSEMBLY) $(DESTDIR)$((gacdir)/$(TARGET); \
+	    $(INSTALL_LIB) $(outdir)$(ASSEMBLY) $(DESTDIR)$(gacdir)/$(TARGET); \
+	    $(INSTALL_LIB) $(outdir)$(NAME).xml $(DESTDIR)$(gacdir)/$(TARGET); \
+	else \
+	    gacutil -i $(outdir)$(ASSEMBLY) -root $(DESTDIR)$(libdir) -package $(TARGET); \
+	    if test -e $(outdir)$(NAME).xml; then \
 		$(INSTALL_LIB) $(outdir)$(NAME).xml $(DESTDIR)$(gacdir)/gac/$(NAME)/$(VERSION)__$(TOKEN)/; \
 		ln -fs  ../gac/$(NAME)/$(VERSION)__$(TOKEN)/$(NAME).xml $(DESTDIR)$(gacdir)/$(TARGET)/$(NAME).xml; \
+	    fi; \
 	fi
 	@if test -e $(outdir)$(NAME).sigdata; then \
 		$(INSTALL_LIB) $(outdir)$(NAME).sigdata $(DESTDIR)$(gacdir)/gac/$(NAME)/$(VERSION)__$(TOKEN)/; \


### PR DESCRIPTION
The MSBuild Fsc task, used for building F# projects, expects to find
fsc.exe next to FSharp.Build.dll. This assumption is violated by placing
the assembly in the GAC. This commit installs the assembly to
PREFIX/lib/mono/4.0 alongside fsc.exe. Previously, builds still worked
in many cases because of the backup fsc.exe resolution in
CompilerLocationUtils. It is implemented in the function
BinFolderOfDefaultFSharpCompiler, which is passed the location of
FSharp.Build.dll (obtained using reflection) as the default search
location. On unix this fails and alternative methods are used to try to
find fsc.exe:
- The location in environment variable FSHARP_COMPILER_BIN is probed.
- A list of hard-coded locations (/Library/Frameworks/..., /usr,
  /usr/local) are searched for the fsharpi bash script. If it is found,
  then a regex is used to see which copy of fsi.exe is invoked and the
  enclosing directory used.
- If everything above fails, the location of the assembly that started
  the build is used. Prior to mono 3.2.7, xbuild.exe was installed to
  PREFIX/lib/mono/4.0 and so fsc.exe would be found. It is now installed
  to PREFIX/lib/mono/xbuild/12.0/bin/.

This fixes compilation of F# projects on mono >= 3.2.7 when installing
in a non-standard PREFIX (not one of the hard-coded locations mentioned
above).
