### PR TITLE
Update control.fs

### DIFF
--- a/src/fsharp/FSharp.Core/control.fs
+++ b/src/fsharp/FSharp.Core/control.fs
@@ -1627,10 +1627,12 @@ namespace Microsoft.FSharp.Control
                     
                     let savedCont = args.cont
                     try
+                      lock rwh <| fun () ->
                         rwh := Some(ThreadPool.RegisterWaitForSingleObject
                                       (waitObject=waitHandle,
                                        callBack=WaitOrTimerCallback(fun _ timeOut ->
                                                     if latch.Enter() then
+                                                        lock rwh <| fun () -> rwh.Value.Value.Unregister(waitHandle)
                                                         rwh := None
                                                         registration.Dispose()
                                                         aux.trampolineHolder.Protect (fun () -> savedCont (not timeOut)) |> unfake),


### PR DESCRIPTION
Fix a race condition causing a memory leak.

Reference update is not an atomic operation, so it can happen that the wait callback runs before the current thread has a a chance to write to rwh. The callback will set rwh to None, and at some point later the main thread will set it with the RegisteredWaitHandle object. Now the callback holds a reference to rwh and you have a memory leak. 
To see why, check the docs for RegisteredWaitHandle. Unless the handle is Unregistered, the WaitCallback is kept alive by the thread pool until the RegisteredWaitHandle finaliser runs. But this will never happen, because the WaitCallback itself keeps it alive. 