### PR TITLE
Readme: slightly simplify & clarify FSharp.Core NuGet section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,23 +244,25 @@ sudo make install
 ### FSharp.Core Deployed with Nuget
 FSharp.Core is also available via Nuget.  
 
-*   [FSharp.Core 3.0 Microsoft Signed](https://www.nuget.org/packages/FSharp.Core.4.3.0.0.Microsoft.Signed)
-*   [FSharp.Core 3.1 Microsoft Signed](https://www.nuget.org/packages/FSharp.Core.Microsoft.Signed)
-*   [FSharp.Core 3.1 Mono Signed](https://www.nuget.org/packages/FSharp.Core.Mono.Signed)
+*   [FSharp.Core for F# 3.0+ Microsoft Signed](https://www.nuget.org/packages/FSharp.Core.4.3.0.0.Microsoft.Signed)
+*   [FSharp.Core for F# 3.1+ Microsoft Signed](https://www.nuget.org/packages/FSharp.Core.Microsoft.Signed)
+*   [FSharp.Core for F# 3.1+ with MonoAndroid and MonoTouch](https://www.nuget.org/packages/FSharp.Core.Mono.Signed)
 
 
 The folder FSharp.Core.Nuget contains the nuget package scripts for the deployment of FSharp.Core.  
 
-There are currently three versions:
+#### FSharp.Core for F# 3.0+ Microsoft Signed
+NuGet Package Id: `FSharp.Core.4.3.0.0.Microsoft.Signed`  
 
-#### FSharp.Core.Microsoft.Signed.3.0
 Contains the following versions Microsoft signed versions: 
 *   .Net 2.0
 *   .Net 4.0
 *   .Net 4.5
 *   Profile 47
 
-#### FSharp.Core.Microsoft.Signed.3.1
+#### FSharp.Core for F# 3.1+ Microsoft Signed
+NuGet Package Id: `FSharp.Core.Microsoft.Signed`  
+
 Contains the following versions Microsoft signed versions: 
 *   .Net 4.0
 *   .Net 4.5
@@ -269,7 +271,9 @@ Contains the following versions Microsoft signed versions:
 *   Profile 78
 *   Profile 259
 
-#### FSharp.Core.Mono.DelaySigned.3.1
+#### FSharp.Core for F# 3.1+ with MonoAndroid and MonoTouch
+NuGet Package Id: `FSharp.Core.Mono.Signed`  
+
 Contains the following versions Microsoft signed versions: 
 *   .Net 4.0
 *   .Net 4.5
@@ -282,5 +286,5 @@ And the following are delay signed with the Mono key:
 *   MonoAndroid
 *   MonoTouch
 
-The FSharp.Core.Mono.DelaySigned.3.1 is normally deployed with a version matching the current tag of the open source build, the Microsoft signed versions use a version which matches the current Microsoft signed versions of FSharp core.
+The FSharp.Core.Mono.Signed package is normally deployed with a version matching the current tag of the open source build, the Microsoft signed versions use a version which matches the current Microsoft signed versions of FSharp core.
 


### PR DESCRIPTION
Previously we used multiple ways to refer to the packages which was quite
confusing, on top of the fact that the package naming and versioning is
very confusing in itself already. I suggest we simplify and clarify the
readme section by using only one human readable title which is close or
identical to the NuGet package title, and the NuGet package id itself.

It seems the nuspec files better be renamed to match their id as well,
but I did not touch them to avoid breaking anything.
