### PR TITLE
Set boundary for Console.CursorTop (fix #168)

### DIFF
--- a/src/fsharp/fsi/console.fs
+++ b/src/fsharp/fsi/console.fs
@@ -131,7 +131,7 @@ module internal Utils =
 type internal Cursor =
     static member ResetTo(top,left) = 
         Utils.guard(fun () -> 
-           Console.CursorTop <- top;
+           Console.CursorTop <- min top (Console.BufferHeight - 1);
            Console.CursorLeft <- left)
     static member Move(inset, delta) =
         let position = Console.CursorTop * (Console.BufferWidth - inset) + (Console.CursorLeft - inset) + delta
@@ -216,6 +216,7 @@ type internal ReadLineConsole() =
             if currLeft < x.Inset then 
                 if currLeft = 0 then Console.Write (if prompt then x.Prompt2 else String(' ',x.Inset))
                 Utils.guard(fun () -> 
+                    Console.CursorTop <- min Console.CursorTop (Console.BufferHeight - 1);
                     Console.CursorLeft <- x.Inset);
 
         // The caller writes the primary prompt.  If we are reading the 2nd and subsequent lines of the


### PR DESCRIPTION
This workaround fixes a long-running bug in `fsharpi` on Linux / Unix, which annoyed me for a while, as previously reported in #168 and #13 (and possibly [this one](https://bugzilla.xamarin.com/show_bug.cgi?id=9814) on Xamarin's issue tracker), i.e. whenever a terminal window is resized and shrinked vertically, an exception `Value must be positive and below the buffer height.` is thrown.

By setting a boundary for `CursorTop`, it is ensured that its value [can never exceed](https://github.com/mono/mono/blob/master/mcs/class/corlib/System/TermInfoDriver.cs#L1225) `BufferHeight`. Once the terminal is shrinked, the cursor always appears on the bottom of the buffer.

(I'm not really sure if this one belongs here or https://visualfsharp.codeplex.com, as one may not dynamically adjust the buffer size on a Windows console so easily. Might not be too relevant for Windows users, but let me know if I should send it there.)
