### PR TITLE
Avoid configure failures when the lib/mono/2.0 directory does not exist.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,9 @@ fi
 MONOGACDIR20="$MONOGACDIR"/2.0
 MONOGACDIR35="$MONOGACDIR"/3.5
 MONOGACDIR40="$MONOGACDIR"/4.0
+MONOGACDIR45="$MONOGACDIR"/4.5
 
-if ! test -e $MONOGACDIR20/mscorlib.dll; then
+if ! test -e $MONOGACDIR20/mscorlib.dll -o -e $MONOGACDIR45/mscorlib.dll; then
 	AC_ERROR(Couldn't find the mono gac directory or mscorlib.dll in the usual places. Set --with-gacdir=<path>)
 fi
 


### PR DESCRIPTION
NET 2.0 support in mono is going away[1], and fsharp includes configure checks which break if lib/mono/2.0 directory does not exist. The attached patch fixes that.

[1]:
http://lists.ximian.com/pipermail/mono-devel-list/2014-October/042145.html
