### PR TITLE
Updated define constants to address bugzilla 24797 and add missing supported features.

### DIFF
--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -141,6 +141,7 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
   <PropertyGroup Condition="'$(TargetFramework)'=='monodroid'">
     <TargetFrameworkVersion>v2.1</TargetFrameworkVersion>
     <TargetFrameworkOutputDirectory>$(TargetFramework)</TargetFrameworkOutputDirectory>
+    <DefineConstants>$(DefineConstants);FX_NO_CUSTOMATTRIBUTEDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FSHARP_CORE_4_5</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_45</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_ATLEAST_40</DefineConstants>


### PR DESCRIPTION
-   Removed FX_NO_STRUCTURAL_EQUALITY, FX_NO_CUSTOMATTRIBUTEDATA as these
  are both provided in mscorlib for monotouch/monodroid.
  _(FX_NO_STRUCTURAL_EQUALITY actually causes an issue with array
  comparisons within tuples, see [bugzilla 24797](https://bugzilla.xamarin.com/show_bug.cgi?id=24797))_
-   Removed FX_NO_BIGINT_CULTURE_PARSE as its already covered by
  FX_NO_BIGINT
-   Added FX_ATLEAST_45, FSHARP_CORE_4_5 as .Net 4.5 features defined
  within are supported by monotouch/monodroid
