### PR TITLE
Fix for installation paths with a space in

### DIFF
--- a/launcher.in
+++ b/launcher.in
@@ -21,4 +21,4 @@ fi
 # location of the default FSharp install in order to find the FSharp compiler binaries (see 
 # fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerLocationUtils.fs). That's a pretty unfortunate
 # way of finding those binaries. And really should be changed.
-$EXEC mono $DEBUG $MONO_OPTIONS @DIR@/@TOOL@ --exename:$(basename $0) "$@"
+$EXEC mono $DEBUG $MONO_OPTIONS @DIR@/@TOOL@ --exename:$(basename "$0") "$@"


### PR DESCRIPTION
basename only takes a single parameter.

If $0 refers to a path containing a space (e.g. something in /cygpath/c/Program Files) then it gets interpreted as two parameters and fails.

Wrapping $0 with speech marks means it'll be interpreted as a single parameter, regardless of spaces.
