### PR TITLE
Remove net_2_0 and net_3_5 dependencies in mono build; mono eliminated them

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -7,14 +7,11 @@ bindir := ${prefix}/bin/
 monolibdir := @MONOLIBDIR@
 monogacdir := @MONOGACDIR@
 
-monogacdir20 := @MONOGACDIR20@
-
 #This is where to find MonoTouch of MonoAndroid, for "make build-monodroid"
 #
 #For now this is hardwired, it should be optionally detected by configure.ac
 monogacdir21 := @abs_top_srcdir@/dependencies/mono/2.1
 
-monogacdir35 := @MONOGACDIR35@
 monogacdir40 := @MONOGACDIR40@
 
 pclenabled47 := @PCLENABLED47@

--- a/configure.ac
+++ b/configure.ac
@@ -58,12 +58,10 @@ if ! test "x$with_gacdir" = "xno"; then
 	MONOGACDIR=$(cd "$with_gacdir/.." && pwd)
 fi
 
-MONOGACDIR20="$MONOGACDIR"/2.0
-MONOGACDIR35="$MONOGACDIR"/3.5
 MONOGACDIR40="$MONOGACDIR"/4.0
 MONOGACDIR45="$MONOGACDIR"/4.5
 
-if ! test -e $MONOGACDIR20/mscorlib.dll -o -e $MONOGACDIR45/mscorlib.dll; then
+if ! test -e $MONOGACDIR40/mscorlib.dll -o -e $MONOGACDIR45/mscorlib.dll; then
 	AC_ERROR(Couldn't find the mono gac directory or mscorlib.dll in the usual places. Set --with-gacdir=<path>)
 fi
 
@@ -107,8 +105,6 @@ AC_SUBST(PCLENABLED259)
 AC_SUBST(MONOLIBDIR)
 AC_SUBST(MONOGACDIR)
 
-AC_SUBST(MONOGACDIR20)
-AC_SUBST(MONOGACDIR35)
 AC_SUBST(MONOGACDIR40)
 
 AC_CONFIG_FILES([

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -42,11 +42,11 @@ build clean install:
 	$(MAKE) -C policy.4.3.FSharp.Core $@
 	$(MAKE) -C policy.2.0.FSharp.Core TargetFramework=net20 $@
 	$(MAKE) -C policy.2.3.FSharp.Core TargetFramework=net20 $@
-	if test -e $MONOGACDIR20/mscorlib.dll; then $(MAKE) -C FSharp.Core TargetFramework=net20 $@;fi
+	if test -e $MONOGACDIR40/mscorlib.dll; then $(MAKE) -C FSharp.Core TargetFramework=net40 $@;fi
 	$(MAKE) -C FSharp.Core TargetFramework=monodroid $@
 	$(MAKE) -C FSharp.Core TargetFramework=monotouch $@
 	$(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=net40 $@
-	if test -e $MONOGACDIR20/mscorlib.dll; then $(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=net20 $@;fi
+	if test -e $MONOGACDIR40/mscorlib.dll; then $(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=net40 $@;fi
 ifeq ("$(pclenabled47)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=portable47 $@
 	$(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=portable47 $@


### PR DESCRIPTION
master mono has removed net_2_0 and net_3_5 profiles, so it is unable to build fsharp with master mono anymore because fsharp on mono seems to make use of net_2_0 to bootstrap build. So, remove them.
