### PR TITLE
Split the all-monotouch-monodroid target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,6 +1,6 @@
 include $(topsrcdir)config.make
 
-all clean install build build-proto all-monotouch-monodroid:
+all clean install build build-proto all-monotouch-monodroid all-monotouch all-monodroid:
 	$(MAKE) -C src/fsharp $@
 
 dist:

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -66,6 +66,13 @@ all-monotouch-monodroid:
 	$(MAKE) -C FSharp.Core TargetFramework=monodroid build
 	$(MAKE) -C FSharp.Core TargetFramework=monotouch build
 
+all-monotouch:
+	$(MAKE) build-proto
+	$(MAKE) -C FSharp.Core TargetFramework=monotouch build
+
+all-monodroid:
+	$(MAKE) build-proto
+	$(MAKE) -C FSharp.Core TargetFramework=monodroid build
 
 
 


### PR DESCRIPTION
Separate the all-monotouch-monodroid target into two all-monotouch and all-monodroid targets.

This makes it possible for the monotouch and the monodroid builds
to not depend on having the other installed.

It also makes the builds faster (by building less).
