### PR TITLE
monodroid & monotouch configured with FX_NO_BIGINT & FX_NO_STRUCTURAL_EQUALITY

### DIFF
--- a/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FSharp.Core</id>
-    <version>3.1.2.1</version>
+    <version>3.1.2.2</version>
     <title>FSharp.Core for F# 3.1</title>
     <authors>F# Software Foundation</authors>
     <owners>F# Software Foundation</owners>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -153,6 +153,8 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <!-- Although Reflection Emit is available on MonoAndroid, we don't use it for FSharp.Core -->
     <!-- because we want the FSharp.Core DLLs to be identical for MonoAndroid and MonoTouch -->
     <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_EMIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_STRUCTURAL_EQUALITY</DefineConstants>
     <AssemblySearchPaths>$(FSharpSourcesRoot)\..\dependencies\mono\2.1\MonoAndroid;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
 
@@ -170,6 +172,8 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <DefineConstants>$(DefineConstants);QUERIES_IN_FSLIB</DefineConstants>
     <DefineConstants>$(DefineConstants);PUT_TYPE_PROVIDERS_IN_FSCORE;</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_EMIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_STRUCTURAL_EQUALITY</DefineConstants>
     <AssemblySearchPaths>$(FSharpSourcesRoot)\..\dependencies\mono\2.1\MonoTouch;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
 


### PR DESCRIPTION
fix fsharp/fsharp#363