### PR TITLE
portable-net45+monoandroid1+monotouch1+xamarinios1

### DIFF
--- a/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
@@ -23,7 +23,7 @@
 
       FSharp.Core built by F# Software Foundation
 
-      MonoAndroid, MonoTouch, Xamarin.iOS (portable-monoandroid1+monotouch1+xamarinios1)
+      MonoAndroid, MonoTouch, Xamarin.iOS (portable-net45+monoandroid1+monotouch1+xamarinios1)
     </description>
     <summary>FSharp.Core for F# 3.1</summary>
     <tags>F#, FSharp, FSharp.Core</tags>

--- a/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FSharp.Core</id>
-    <version>3.1.2.1</version>
+    <version>3.1.2.2</version>
     <title>FSharp.Core for F# 3.1</title>
     <authors>F# Software Foundation</authors>
     <owners>F# Software Foundation</owners>

--- a/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
@@ -16,15 +16,14 @@
       FSharp.Core redistributables from Visual F# 3.1.2
 
       .NET 4.0
-      .NET Portable Profile 7 (portable-net45+netcore45+MonoAndroid1+MonoTouch1)
-      .NET Portable Profile 47 (portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1)
-      .NET Portable Profile 78 (portable-net45+netcore45+wp8+MonoAndroid1+MonoTouch1)
-      .NET Portable Profile 259 (portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1)
+      .NET Portable Profile 7 (portable-net45+netcore45)
+      .NET Portable Profile 47 (portable-net45+sl5+netcore45)
+      .NET Portable Profile 78 (portable-net45+netcore45+wp8)
+      .NET Portable Profile 259 (portable-net45+netcore45+wpa81+wp8)
 
       FSharp.Core built by F# Software Foundation
 
-      MonoAndroid
-      MonoTouch
+      MonoAndroid, MonoTouch, Xamarin.iOS (portable-monoandroid1+monotouch1+xamarinios1)
     </description>
     <summary>FSharp.Core for F# 3.1</summary>
     <tags>F#, FSharp, FSharp.Core</tags>
@@ -38,40 +37,34 @@
     <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.3.1.0\FSharp.Core.xml" target="lib\net40\FSharp.Core.xml" />
 
     <!-- .NET Portable Profile 7 -->
-    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.dll" target="lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.optdata" target="lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.optdata" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.sigdata" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.xml" target="lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.xml" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.dll" target="lib\portable-net45+netcore45\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.optdata" target="lib\portable-net45+netcore45\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.sigdata" target="lib\portable-net45+netcore45\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.3.1.0\FSharp.Core.xml" target="lib\portable-net45+netcore45\FSharp.Core.xml" />
 
     <!-- .NET Portable Profile 47-->
-    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.dll" target="lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll" />
-    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.optdata" target="lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.optdata" />
-    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.sigdata" target="lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.sigdata" />
-    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.xml" target="lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.xml" />
+    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.dll" target="lib\portable-net45+sl5+netcore45\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.optdata" target="lib\portable-net45+sl5+netcore45\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.sigdata" target="lib\portable-net45+sl5+netcore45\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETPortable\2.3.5.1\FSharp.Core.xml" target="lib\portable-net45+sl5+netcore45\FSharp.Core.xml" />
 
     <!-- .NET Portable Profile 78 -->
-    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.dll" target="lib\portable-net45+netcore45+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.dll" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.optdata" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.sigdata" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.xml" target="lib\portable-net45+netcore45+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.xml" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.dll" target="lib\portable-net45+netcore45+wp8\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wp8\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wp8\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.78.3.1\FSharp.Core.xml" target="lib\portable-net45+netcore45+wp8\FSharp.Core.xml" />
 
     <!-- .NET Portable Profile 259 -->
-    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.dll" target="lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.dll" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.optdata" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.sigdata" />
-    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.xml" target="lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.xml" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.dll" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.xml" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.xml" />
 
-    <!-- MonoAndroid -->
-    <file src="..\lib\release\monodroid\FSharp.Core.dll" target="lib\MonoAndroid\FSharp.Core.dll" />
-    <file src="..\lib\release\monodroid\FSharp.Core.optdata" target="lib\MonoAndroid\FSharp.Core.optdata" />
-    <file src="..\lib\release\monodroid\FSharp.Core.sigdata" target="lib\MonoAndroid\FSharp.Core.sigdata" />
-    <file src="..\lib\release\monodroid\FSharp.Core.xml" target="lib\MonoAndroid\FSharp.Core.xml" />
-
-    <!-- MonoTouch -->
-    <file src="..\lib\release\monotouch\FSharp.Core.dll" target="lib\MonoTouch\FSharp.Core.dll" />
-    <file src="..\lib\release\monotouch\FSharp.Core.optdata" target="lib\MonoTouch\FSharp.Core.optdata" />
-    <file src="..\lib\release\monotouch\FSharp.Core.sigdata" target="lib\MonoTouch\FSharp.Core.sigdata" />
-    <file src="..\lib\release\monotouch\FSharp.Core.xml" target="lib\MonoTouch\FSharp.Core.xml" />
+    <!-- MonoAndroid, MonoTouch, Xamarin.iOS -->
+    <file src="..\lib\release\monotouch\FSharp.Core.dll" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.dll" />
+    <file src="..\lib\release\monotouch\FSharp.Core.optdata" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.optdata" />
+    <file src="..\lib\release\monotouch\FSharp.Core.sigdata" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.sigdata" />
+    <file src="..\lib\release\monotouch\FSharp.Core.xml" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.xml" />
     
   </files>
 </package>

--- a/build.bat
+++ b/build.bat
@@ -22,5 +22,4 @@ ngen install lib\proto\fsc-proto.exe
 %_msbuildexe% src\fsharp-library-build.proj /p:TargetFramework=portable78 /p:Configuration=Release
 %_msbuildexe% src\fsharp-library-build.proj /p:TargetFramework=portable259 /p:Configuration=Release
 %_msbuildexe% src\fsharp-library-build.proj /p:TargetFramework=sl5 /p:Configuration=Release
-%_msbuildexe% src\fsharp-library-build.proj /p:TargetFramework=monodroid /p:Configuration=Release /p:KeyFile=..\..\..\mono.snk
 %_msbuildexe% src\fsharp-library-build.proj /p:TargetFramework=monotouch /p:Configuration=Release /p:KeyFile=..\..\..\mono.snk

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -22,7 +22,7 @@
     <AssemblyVersion Condition="'$(TargetFramework)' == 'net20'">2.3.1.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable47' ">2.3.5.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'monodroid' ">2.3.98.1</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'monotouch' ">2.3.98.2</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'monotouch' ">2.3.98.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable7'">3.3.1.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable78'">3.78.3.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable259'">3.259.3.1</AssemblyVersion>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -22,7 +22,7 @@
     <AssemblyVersion Condition="'$(TargetFramework)' == 'net20'">2.3.1.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable47' ">2.3.5.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'monodroid' ">2.3.98.1</AssemblyVersion>
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'monotouch' ">2.3.98.1</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'monotouch' ">2.3.98.2</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable7'">3.3.1.0</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable78'">3.78.3.1</AssemblyVersion>
     <AssemblyVersion Condition="'$(TargetFramework)' == 'portable259'">3.259.3.1</AssemblyVersion>

--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -153,6 +153,8 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <!-- Although Reflection Emit is available on MonoAndroid, we don't use it for FSharp.Core -->
     <!-- because we want the FSharp.Core DLLs to be identical for MonoAndroid and MonoTouch -->
     <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_EMIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_STRUCTURAL_EQUALITY</DefineConstants>
     <AssemblySearchPaths>$(FSharpSourcesRoot)\..\dependencies\mono\2.1\MonoAndroid;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
 
@@ -170,6 +172,8 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <DefineConstants>$(DefineConstants);QUERIES_IN_FSLIB</DefineConstants>
     <DefineConstants>$(DefineConstants);PUT_TYPE_PROVIDERS_IN_FSCORE;</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_REFLECTION_EMIT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FX_NO_STRUCTURAL_EQUALITY</DefineConstants>
     <AssemblySearchPaths>$(FSharpSourcesRoot)\..\dependencies\mono\2.1\MonoTouch;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
 


### PR DESCRIPTION
This is work in progress for #367 builds on top of #364. Removed `MonoAndroid1+MonoTouch1` from other profiles. Ships a single portable library for MonoAndroid, MonoTouch, and Xamarin.iOS. I tested with a local build on Xamarin Studio on Mac and Windows. I'm having a bit a difficulty getting Visual Studio to update to the library. I'm hoping that incrementing the AssemblyVersion will help.

Not yet ready to merge, but this pull request will build a nupkg that we can test.