### PR TITLE
Add mono-net45 target framework

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -46,6 +46,12 @@ TARGET = 4.0
 outsuffix = .
 endif
 
+ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-mono-net45-)
+VERSION = 4.3.1.0
+TARGET = 4.5
+outsuffix = .
+endif
+
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-monodroid-)
 VERSION = 2.3.98.1
 TARGET = monodroid


### PR DESCRIPTION
Add mono-net45 target framework to correctly install fsharp to 4.5 mono location. Starting from mono 4.0 the default lib/mono/4.0 is reference assemblies location only and cannot be used for execution