### PR TITLE
Tentative Fix for #391

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -21,6 +21,8 @@ pclenabled47 := @PCLENABLED47@
 pclenabled7 := @PCLENABLED7@
 pclenabled78 := @PCLENABLED78@
 pclenabled259 := @PCLENABLED259@
+monotouchenabled := @MONOTOUCHENABLED@
+monodroidenabled := @MONODROIDENABLED@
 
 gacdir := ${libdir}mono
 

--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,16 @@ AC_MSG_NOTICE(PCL Reference Assemblies for Profile 47 found: $PCLENABLED47)
 AC_SUBST(PCLENABLED47)
 
 
+if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.0/Profile/Profile47/mscorlib.dll; then
+   PCLENABLED47=yes
+else
+   PCLENABLED47=no
+fi
+AC_MSG_NOTICE(PCL Reference Assemblies for Profile 47 found: $PCLENABLED47)
+
+AC_SUBST(PCLENABLED47)
+
+
 if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.5/Profile/Profile7/System.Runtime.dll; then
    PCLENABLED7=yes
 else
@@ -103,6 +113,16 @@ fi
 AC_MSG_NOTICE(PCL Reference Assemblies for Profile 259 found: $PCLENABLED259)
 
 AC_SUBST(PCLENABLED259)
+
+# We enable MonoTouch and MonoDroid builds if PCL components are available.
+# These build using binaries from dependencies/mono/2.1, but see
+# https://github.com/fsharp/fsharp/issues/391 where PCL is a requirement of
+# Microsoft.Common.targets when used in this configuration
+MONOTOUCHENABLED=$PCLENABLED78
+MONODROIDENABLED=$PCLENABLED78
+
+AC_SUBST(MONOTOUCHENABLED)
+AC_SUBST(MONODROIDENABLED)
 
 AC_SUBST(MONOLIBDIR)
 AC_SUBST(MONOGACDIR)

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -43,8 +43,12 @@ build clean install:
 	$(MAKE) -C policy.2.0.FSharp.Core TargetFramework=net20 $@
 	$(MAKE) -C policy.2.3.FSharp.Core TargetFramework=net20 $@
 	if test -e $MONOGACDIR20/mscorlib.dll; then $(MAKE) -C FSharp.Core TargetFramework=net20 $@;fi
+ifeq ("$(monodroidenabled)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=monodroid $@
+endif
+ifeq ("$(monotouchenabled)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=monotouch $@
+endif
 	$(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=net40 $@
 	if test -e $MONOGACDIR20/mscorlib.dll; then $(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=net20 $@;fi
 ifeq ("$(pclenabled47)", "yes")
@@ -63,16 +67,24 @@ endif
 
 all-monotouch-monodroid:
 	$(MAKE) build-proto
+ifeq ("$(monodroidenabled)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=monodroid build
+endif
+ifeq ("$(monotouchenabled)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=monotouch build
+endif
 
 all-monotouch:
 	$(MAKE) build-proto
+ifeq ("$(monotouchenabled)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=monotouch build
+endif
 
 all-monodroid:
 	$(MAKE) build-proto
+ifeq ("$(monodroidenabled)", "yes")
 	$(MAKE) -C FSharp.Core TargetFramework=monodroid build
+endif
 
 
 


### PR DESCRIPTION
This is a tentative fix for #391 - only build monotouch and monodroid if PCL bits are also available - the PCL binaries seem to be required by Microsoft.Common.targets.