### PR TITLE
configure: require Mono 4.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,15 +20,15 @@ fi
 AC_MSG_NOTICE("pkg-config: $PKG_CONFIG")
 AC_MSG_NOTICE("PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR")
 
-MONO_REQUIRED_VERSION=3.0
-MONO_RECOMMENDED_VERSION=3.2
+MONO_REQUIRED_VERSION=4.0
+MONO_RECOMMENDED_VERSION=4.0
 
 if ! $PKG_CONFIG --atleast-version=$MONO_REQUIRED_VERSION mono; then
 	AC_MSG_ERROR("You need mono $MONO_REQUIRED_VERSION")
 fi
 
 if ! $PKG_CONFIG --atleast-version=$MONO_RECOMMENDED_VERSION mono; then
-	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, for better GC performance])
+	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended])
 fi
 
 # Checks for libraries.


### PR DESCRIPTION
Since the build change [1] was committed, fsharp repository cannot
be built with mono versions previous to 4.0, so it's better to
fail fast at configure time than to give obscure error messages
at build time.

Strictly speaking, this change should have been part of this PR [2].

[1]: https://github.com/fsharp/fsharp/commit/735646a82ed17c2df9dcda7435174c87269344d2
[2]: https://github.com/fsharp/fsharp/pull/388