### PR TITLE
correct if, possible pass of negative number

### DIFF
--- a/src/fsharp/fsi/fsi.fs
+++ b/src/fsharp/fsi/fsi.fs
@@ -309,7 +309,7 @@ type internal FsiStdinSyphon(errorWriter: TextWriter) =
             let rec prune (text:string) =
                 let stdinReset = "# 1 \"stdin\"\n"
                 let idx = text.IndexOf(stdinReset,StringComparison.Ordinal)
-                if idx <> -1 then
+                if idx >= 0 then
                     prune (text.Substring(idx + stdinReset.Length))
                 else
                     text


### PR DESCRIPTION
Should check >= 0 not <> -1. In practice the likelihood of index of behaviour changing is low but ...