### PR TITLE
make pre-release builds on AppVeyor

### DIFF
--- a/FSharp.Compiler.Tools.Nuget/FSharp.Compiler.Tools.3.1.nuspec
+++ b/FSharp.Compiler.Tools.Nuget/FSharp.Compiler.Tools.3.1.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FSharp.Compiler.Tools</id>
-    <version>3.1.2.2</version>
+    <version>0.0.0</version>
     <title>FSharp.Compiler.Tools for F# 3.1</title>
     <authors>F# Software Foundation</authors>
     <owners>F# Software Foundation</owners>

--- a/FSharp.Compiler.Tools.Nuget/build.cmd
+++ b/FSharp.Compiler.Tools.Nuget/build.cmd
@@ -1,2 +1,0 @@
-cd %~dp0
-..\FSharp.Core.Nuget\.nuget\NuGet.exe pack FSharp.Compiler.Tools.3.1.nuspec -NoDefaultExcludes

--- a/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.3.1.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>FSharp.Core</id>
-    <version>3.1.2.2</version>
+    <version>0.0.0</version>
     <title>FSharp.Core for F# 3.1</title>
     <authors>F# Software Foundation</authors>
     <owners>F# Software Foundation</owners>
@@ -15,6 +15,7 @@
 
       FSharp.Core redistributables from Visual F# 3.1.2
 
+      .NET 2.0
       .NET 4.0
       .NET Portable Profile 7 (portable-net45+netcore45)
       .NET Portable Profile 47 (portable-net45+sl5+netcore45)
@@ -29,6 +30,11 @@
     <tags>F#, FSharp, FSharp.Core</tags>
   </metadata>
   <files>
+    <!-- .NET 2.0 -->
+    <file src="..\lib\bootstrap\signed\.NETFramework\v2.0\2.3.0.0\FSharp.Core.dll" target="lib\net20\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v2.0\2.3.0.0\FSharp.Core.optdata" target="lib\net20\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v2.0\2.3.0.0\FSharp.Core.sigdata" target="lib\net20\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v2.0\2.3.0.0\FSharp.Core.xml" target="lib\net20\FSharp.Core.xml" />
 
     <!-- .NET 4.0 -->
     <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.3.1.0\FSharp.Core.dll" target="lib\net40\FSharp.Core.dll" />
@@ -59,12 +65,11 @@
     <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.optdata" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.optdata" />
     <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.sigdata" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.sigdata" />
     <file src="..\lib\bootstrap\signed\.NETCore\3.259.3.1\FSharp.Core.xml" target="lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.xml" />
-
+    
     <!-- MonoAndroid, MonoTouch, Xamarin.iOS -->
     <file src="..\lib\release\monotouch\FSharp.Core.dll" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.dll" />
     <file src="..\lib\release\monotouch\FSharp.Core.optdata" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.optdata" />
     <file src="..\lib\release\monotouch\FSharp.Core.sigdata" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.sigdata" />
     <file src="..\lib\release\monotouch\FSharp.Core.xml" target="lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.xml" />
-    
   </files>
 </package>

--- a/FSharp.Core.Nuget/build.cmd
+++ b/FSharp.Core.Nuget/build.cmd
@@ -1,2 +1,0 @@
-cd %~dp0
-.nuget\NuGet.exe pack FSharp.Core.3.1.nuspec -NoDefaultExcludes

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,0 +1,19 @@
+
+# the version under development, update after a release
+$version = '3.1.2.3'
+
+# append the AppVeyor build number as the pre-release version
+if ($env:appveyor){
+    $version = $version + '-b' + [int]::Parse($env:appveyor_build_number).ToString('000')
+}
+
+$nuget = (gi .\FSharp.Core.Nuget\.nuget\NuGet.exe).FullName
+
+function pack($nuspec){
+    pushd([IO.Path]::GetDirectoryName($nuspec))
+    & $nuget pack $nuspec -Version $version -NoDefaultExcludes
+    popd
+}
+
+pack(gi .\FSharp.Core.Nuget\FSharp.Core.3.1.nuspec)
+pack(gi .\FSharp.Compiler.Tools.Nuget\FSharp.Compiler.Tools.3.1.nuspec)

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -5,12 +5,16 @@ $version = '3.1.2.3'
 # append the AppVeyor build number as the pre-release version
 if ($env:appveyor){
     $version = $version + '-b' + [int]::Parse($env:appveyor_build_number).ToString('000')
+} else {
+    $version = $version + '-b001'
 }
 
 $nuget = (gi .\FSharp.Core.Nuget\.nuget\NuGet.exe).FullName
 
 function pack($nuspec){
-    pushd([IO.Path]::GetDirectoryName($nuspec))
+    $dir = [IO.Path]::GetDirectoryName($nuspec)
+    rm "$dir\*.nupkg"
+    pushd $dir
     & $nuget pack $nuspec -Version $version -NoDefaultExcludes
     popd
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ init:
   - git config --global core.autocrlf input
 build_script:
   - cmd: build.bat
-  - ps: appveyor.ps1
+  - ps: .\appveyor.ps1
 test: off
 version: '{build}'
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,11 @@ init:
   - git config --global core.autocrlf input
 build_script:
   - cmd: build.bat
-  - cmd: FSharp.Core.Nuget\build.cmd
+  - ps: appveyor.ps1
 test: off
 version: '{build}'
 artifacts:
   - path: lib\release
     name: release
   - path: FSharp.Core.Nuget\*.nupkg
+  - path: FSharp.Compiler.Tools.Nuget\*.nupkg


### PR DESCRIPTION
This PR makes each build on AppVeyor be a pre-release build. The idea is to merge this is and then come up with a plan where release builds can be based of of git tags. It is how I do it for SourceLink and at work.

Let's take advantage of the AppVeyor project feed. Can someone with @fsgit credentials, please go here and rename the project feed to `fsharp-fsharp`. You could also use just `fsharp` or `fsgit-fsharp`, but I thought the GitHub repo name was a good convention. Following that convention, I named the feed for my fork `ctaggart-fsharp`. 

https://ci.appveyor.com/project/fsgit/fsharp/settings/nuget

![image](https://cloud.githubusercontent.com/assets/80104/8536861/b1e1aba0-240b-11e5-93ca-d784e37fe696.png)

@eiriktsarpalis You can test by adding the feed as a source in `paket.dependencies`.

![image](https://cloud.githubusercontent.com/assets/80104/8536830/51097a4c-240b-11e5-98ca-1ab6a3f2d7b9.png)

This fixes #430. Here are the versions in the nupkg.
```
lib\net20\FSharp.Core.dll
  2.3.0.0     2.3.50727.0    
lib\net40\FSharp.Core.dll
  4.3.1.0     4.31.30815.0   
lib\portable-net45+monoandroid1+monotouch1+xamarinios1\FSharp.Core.dll
  2.3.98.1    2.3.98.1       
lib\portable-net45+netcore45\FSharp.Core.dll
  3.3.1.0     3.31.30815.0   
lib\portable-net45+netcore45+wp8\FSharp.Core.dll
  3.78.3.1    3.78.30815.0   
lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll
  3.259.3.1   3.259.30815.0  
lib\portable-net45+sl5+netcore45\FSharp.Core.dll
  2.3.5.1     2.3.30815.0    
```