### PR TITLE
Update portable targets for the Mono 4.0 upgrade

### DIFF
--- a/src/fsharp/FSharp.Build/Microsoft.Portable.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.Portable.FSharp.Targets
@@ -44,7 +44,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- END MONO 3.2.7 WORKAROUND PART 1 -->
 
 
-	<Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+	<Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets" />
 
 
     <!-- START MONO 3.2.7 WORKAROUND PART 2 -->


### PR DESCRIPTION
Why does everyone always forget about PCLs? :-(

#388 broke PCLs because `Microsoft.FSharp.Targets` and `Microsoft.Portable.FSharp.Targets` are installed into 4.5 now... but `Microsoft.Portable.FSharp.Targets` references `Microsoft.FSharp.Targets` using the `4.0` path.