### PR TITLE
undo commit 52a725233 which caused binary compat break in FSharp.Core

### DIFF
--- a/src/fsharp/FSharp.Core/prim-types.fs
+++ b/src/fsharp/FSharp.Core/prim-types.fs
@@ -646,17 +646,16 @@ namespace Microsoft.FSharp.Core
 
     module LanguagePrimitives =  
    
-        [<Sealed>]
-        type (* internal *) ErrorStrings =
+        module (* internal *) ErrorStrings =
             // inline functions cannot call GetString, so we must make these bits public
-            static member AddressOpNotFirstClassString with get () = SR.GetString(SR.addressOpNotFirstClass)
-            static member NoNegateMinValueString with get () = SR.GetString(SR.noNegateMinValue)
+            let AddressOpNotFirstClassString = SR.GetString(SR.addressOpNotFirstClass)
+            let NoNegateMinValueString = SR.GetString(SR.noNegateMinValue)
             // needs to be public to be visible from inline function 'average' and others
-            static member InputSequenceEmptyString with get () = SR.GetString(SR.inputSequenceEmpty) 
+            let InputSequenceEmptyString = SR.GetString(SR.inputSequenceEmpty) 
             // needs to be public to be visible from inline function 'average' and others
-            static member InputArrayEmptyString with get () = SR.GetString(SR.arrayWasEmpty) 
+            let InputArrayEmptyString = SR.GetString(SR.arrayWasEmpty) 
             // needs to be public to be visible from inline function 'average' and others
-            static member InputMustBeNonNegativeString with get () = SR.GetString(SR.inputMustBeNonNegative)
+            let InputMustBeNonNegativeString = SR.GetString(SR.inputMustBeNonNegative)
             
         [<CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")>]  // nested module OK              
         module IntrinsicOperators =        

--- a/src/fsharp/FSharp.Core/prim-types.fsi
+++ b/src/fsharp/FSharp.Core/prim-types.fsi
@@ -982,24 +982,23 @@ namespace Microsoft.FSharp.Core
         /// <returns>The division result.</returns>
         val inline DivideByInt< ^T >  : x:^T -> y:int -> ^T when ^T : (static member DivideByInt : ^T * int -> ^T) 
 
-        /// <summary>For internal use only</summary>
-        [<Sealed>]
-        type (* internal *) ErrorStrings = 
+        /// <summary>For compiler use only</summary>
+        module (* internal *) ErrorStrings = 
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            static member InputSequenceEmptyString : string with get
+            val InputSequenceEmptyString : string
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            static member InputArrayEmptyString : string with get
+            val InputArrayEmptyString : string
         
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            static member AddressOpNotFirstClassString : string with get
+            val AddressOpNotFirstClassString : string
 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            static member NoNegateMinValueString : string with get
+            val NoNegateMinValueString : string
                 
             [<CompilerMessage("This value is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            static member InputMustBeNonNegativeString : string with get
+            val InputMustBeNonNegativeString : string
                 
 
         //-------------------------------------------------------------------------


### PR DESCRIPTION
Undoes part of commit 52a725233, see also https://github.com/Microsoft/visualfsharp/commit/52a7252337983b093c7c0b1e5a4361de259cbe7c#comments