### PR TITLE
Find xbuild on El Capitan

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -131,6 +131,8 @@ INSTALL_DATA = $(INSTALL) -c -m 644
 INSTALL_BIN = $(INSTALL) -c -m 755
 INSTALL_LIB = $(INSTALL_BIN)
 
+XBUILD = @XBUILD@
+
 EXTRA_DIST = configure
 NO_DIST = .gitignore lib/debug lib/proto lib/release
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,18 @@ fi
 AC_MSG_NOTICE("pkg-config: $PKG_CONFIG")
 AC_MSG_NOTICE("PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR")
 
+# On OSX El Capitan, xbuild is no longer in PATH, so we need to use the full path.
+AC_PATH_PROG(XBUILD, xbuild, no)
+osx_xbuild=/Library/Frameworks/Mono.framework/Versions/Current/bin/xbuild
+if test "x$XBUILD" == "xno"; then
+  if test -e $osx_xbuild; then
+    XBUILD=$osx_xbuild
+  else
+    AC_MSG_ERROR([Could not find xbuild])
+  fi
+fi
+AC_MSG_NOTICE(xbuild: $XBUILD)
+
 MONO_REQUIRED_VERSION=3.0
 MONO_RECOMMENDED_VERSION=3.2
 

--- a/src/fsharp/FSharp.Build-proto/Makefile.in
+++ b/src/fsharp/FSharp.Build-proto/Makefile.in
@@ -6,7 +6,7 @@ srcdir := @abs_srcdir@/
 include @abs_top_builddir@/config.make
 
 build-proto:
-	MONO_ENV_OPTIONS=$(monoopts) xbuild /p:Configuration=Proto
+	MONO_ENV_OPTIONS=$(monoopts) $(XBUILD) /p:Configuration=Proto
 
 include $(topdir)/src/fsharp/targets.make
 

--- a/src/fsharp/FSharp.Compiler-proto/Makefile.in
+++ b/src/fsharp/FSharp.Compiler-proto/Makefile.in
@@ -6,6 +6,6 @@ srcdir := @abs_srcdir@/
 include @abs_top_builddir@/config.make
 
 build-proto:
-	MONO_ENV_OPTIONS=$(monoopts) xbuild /p:Configuration=Proto
+	MONO_ENV_OPTIONS=$(monoopts) $(XBUILD) /p:Configuration=Proto
 
 include $(topdir)/src/fsharp/targets.make

--- a/src/fsharp/Fsc-proto/Makefile.in
+++ b/src/fsharp/Fsc-proto/Makefile.in
@@ -6,7 +6,7 @@ srcdir := @abs_srcdir@/
 include @abs_top_builddir@/config.make
 
 build-proto:
-	MONO_ENV_OPTIONS=$(monoopts) xbuild /p:Configuration=Proto
+	MONO_ENV_OPTIONS=$(monoopts) $(XBUILD) /p:Configuration=Proto
 	chmod +x $(protodir)fsc-proto.exe
 
 include $(topdir)/src/fsharp/targets.make

--- a/src/fsharp/targets.make
+++ b/src/fsharp/targets.make
@@ -3,10 +3,10 @@ SOURCES := $(patsubst $(srcdir)$(tmpdir)%,$(tmpdir)%,$(patsubst %,$(srcdir)%,$(s
 .PHONY: install install-lib-net20 install-lib-monodroid install-lib-net40
 
 build:
-	MONO_ENV_OPTIONS=$(monoopts) xbuild /p:Configuration=$(Configuration) /p:TargetFramework=$(TargetFramework) /p:MonoLibDir40=$(monogacdir40) /p:FSharpCoreBackVersion=$(FSharpCoreBackVersion)
+	MONO_ENV_OPTIONS=$(monoopts) $(XBUILD) /p:Configuration=$(Configuration) /p:TargetFramework=$(TargetFramework) /p:MonoLibDir40=$(monogacdir40) /p:FSharpCoreBackVersion=$(FSharpCoreBackVersion)
 
 clean:
-	xbuild /p:Configuration=$(Configuration) /p:TargetFramework=$(TargetFramework) /t:Clean
+	$(XBUILD) /p:Configuration=$(Configuration) /p:TargetFramework=$(TargetFramework) /t:Clean
 
 # Install the library binaries in the GAC and the framework directory, 
 # Install .optdata/.sigdata if they exist (they go alongside FSharp.Core)


### PR DESCRIPTION
Detect when xbuild is not in PATH (happens on El Capitán), and check
if it's in the standard OSX location. If it is, use the full path
instead of just 'xbuild'.

This makes F# build on El Capitan for Xamarin.iOS and Xamarin.Mac.