### PR TITLE
Fix install of FSharp.Core DLLs

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -37,118 +37,149 @@ outsuffix = $(TargetFramework)
 
 # Version number mappings for various versions of FSharp.Core
 
-
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-net40-)
 VERSION = 4.4.0.0
 TARGET = 4.5
+PKGINSTALL = yes
+REFASSEMPATH = .NETFramework/v4.0
 outsuffix = .
+endif
+
+ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-net20-)
+VERSION = 2.3.0.0
+TARGET = 2.0
+REFASSEMPATH = .NETFramework/v2.0
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-monodroid-)
 VERSION = 3.98.4.0
-TARGET = monodroid
+TARGET = $(TargetFramework)
+outsuffix = $(TargetFramework)
 endif
 
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-monotouch-)
 VERSION = 3.98.4.0
-TARGET = monotouch
+TARGET = $(TargetFramework)
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-xamarinwatchos-)
 VERSION = 3.98.4.0
-TARGET = xamarinwatchos
+TARGET = $(TargetFramework)
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-xamarinmacmobile-)
 VERSION = 3.99.4.0
-TARGET = xamarinmacmobile
+TARGET = $(TargetFramework)
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-xamarinmacfull-)
 VERSION = 3.100.4.0
-TARGET = xamarinmacfull
+TARGET = $(TargetFramework)
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable47-)
 VERSION = 3.47.4.0
-TARGET = portable47
+TARGET = $(TargetFramework)
 PCLPATH = .NETPortable
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable7-)
 VERSION = 3.7.4.0
-TARGET = portable7
+TARGET = $(TargetFramework)
 PCLPATH = .NETCore
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable78-)
 VERSION = 3.78.4.0
-TARGET = portable78
+TARGET = $(TargetFramework)
 PCLPATH = .NETCore
+outsuffix = $(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable259-)
 VERSION = 3.259.4.0
-TARGET = portable259
+TARGET = $(TargetFramework)
 PCLPATH = .NETCore
+outsuffix = $(TargetFramework)
 endif
 
 # Version number mappings for various back versions of FSharp.Core (F# 3.0 versions of FSharp.Core)
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-net20-3.0)
 VERSION = 2.3.0.0
-TARGET = 2.0
+TARGET = fsharp30/2.0
+REFASSEMPATH = .NETFramework/v2.0
 outsuffix = fsharp30/$(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-net40-3.0)
 VERSION = 4.3.0.0
-TARGET = 4.5
+TARGET = fsharp30/4.5
+REFASSEMPATH = .NETFramework/v4.0
 outsuffix = fsharp30/$(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable47-3.0)
 VERSION = 2.3.5.0
-TARGET = portable47
+TARGET = fsharp30/$(TargetFramework)
 PCLPATH = .NETPortable
 outsuffix = fsharp30/$(TargetFramework)
 endif
 
 # Version number mappings for various back versions of FSharp.Core (F# 3.1 versions of FSharp.Core)
 
+ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-net20-3.1)
+VERSION = 2.3.1.0
+TARGET = fsharp31/2.0
+REFASSEMPATH = .NETFramework/v2.0
+outsuffix = fsharp31/$(TargetFramework)
+endif
+
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-net40-3.1)
 VERSION = 4.3.1.0
-TARGET = 4.5
+TARGET = fsharp31/4.5
+REFASSEMPATH = .NETFramework/v4.0
 outsuffix = fsharp31/$(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-monodroid-3.1)
 VERSION = 2.3.98.1
-TARGET = fsharp31/monodroid
+TARGET = fsharp31/$(TargetFramework)
+outsuffix = fsharp31/$(TargetFramework)
 endif
 
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-monotouch-3.1)
 VERSION = 2.3.98.1
-TARGET = fsharp31/monotouch
+TARGET = fsharp31/$(TargetFramework)
+outsuffix = fsharp31/$(TargetFramework)
 endif
 
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-xamarinmacmobile-3.1)
 VERSION = 2.3.99.1
-TARGET = fsharp31/xamarinmacmobile
+TARGET = fsharp31/$(TargetFramework)
+outsuffix = fsharp31/$(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-xamarinmacfull-3.1)
 VERSION = 2.3.100.1
-TARGET = fsharp31/xamarinmacfull
+TARGET = fsharp31/$(TargetFramework)
+outsuffix = fsharp31/$(TargetFramework)
 endif
 
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable7-3.1)
 VERSION = 3.3.1.0
-TARGET = portable7
+TARGET = fsharp31/$(TargetFramework)
 PCLPATH = .NETCore
 outsuffix = fsharp31/$(TargetFramework)
 endif
@@ -156,7 +187,7 @@ endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable47-3.1)
 VERSION = 2.3.5.1
-TARGET = portable47
+TARGET = fsharp31/$(TargetFramework)
 PCLPATH = .NETPortable
 outsuffix = fsharp31/$(TargetFramework)
 endif
@@ -165,21 +196,21 @@ endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable78-3.1)
 VERSION = 3.78.3.1
-TARGET = portable78
+TARGET = fsharp31/$(TargetFramework)
 PCLPATH = .NETCore
 outsuffix = fsharp31/$(TargetFramework)
 endif
 
 ifeq (x-$(TargetFramework)-$(FSharpCoreBackVersion),x-portable259-3.1)
 VERSION = 3.259.3.1
-TARGET = portable259
+TARGET = fsharp31/$(TargetFramework)
 PCLPATH = .NETCore
 outsuffix = fsharp31/$(TargetFramework)
 endif
 
 
 
-DELAY_SIGN_TOKEN = b03f5f7f11d50a3a
+FSCORE_DELAY_SIGN_TOKEN = b03f5f7f11d50a3a
 SIGN_TOKEN = f536804aa0eb945b
 
 bootstrapdir = $(bootstrap)/4.0/

--- a/src/fsharp/FSharp.Build/Makefile.in
+++ b/src/fsharp/FSharp.Build/Makefile.in
@@ -8,5 +8,5 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-lib install-lib-net45
+install: install-lib install-lib-net40
 

--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile.in
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile.in
@@ -8,7 +8,7 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-lib install-lib-net45
+install: install-lib install-lib-net40
 
 
 

--- a/src/fsharp/FSharp.Compiler.Server.Shared/Makefile.in
+++ b/src/fsharp/FSharp.Compiler.Server.Shared/Makefile.in
@@ -8,7 +8,7 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-lib install-lib-net45
+install: install-lib install-lib-net40
 
 
 

--- a/src/fsharp/FSharp.Compiler/Makefile.in
+++ b/src/fsharp/FSharp.Compiler/Makefile.in
@@ -8,7 +8,7 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-lib install-lib-net45
+install: install-lib install-lib-net40
 
 
 

--- a/src/fsharp/FSharp.Core/Makefile.in
+++ b/src/fsharp/FSharp.Core/Makefile.in
@@ -1,7 +1,7 @@
 NAME=FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
-TOKEN=$(DELAY_SIGN_TOKEN)
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 
@@ -9,6 +9,6 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-lib install-lib-net45 
+install: install-lib install-lib-net40 
 
 

--- a/src/fsharp/FSharp.Data.TypeProviders/Makefile.in
+++ b/src/fsharp/FSharp.Data.TypeProviders/Makefile.in
@@ -8,7 +8,7 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-lib install-lib-net45
+install: install-lib install-lib-net40
 
 
 

--- a/src/fsharp/Makefile.in
+++ b/src/fsharp/Makefile.in
@@ -36,16 +36,14 @@ build clean install:
 	$(MAKE) -C fsi $@
 	$(MAKE) -C fsiAnyCpu $@
 	$(MAKE) -C policy.2.0.FSharp.Core $@
-	$(MAKE) -C policy.4.0.FSharp.Core $@
 	$(MAKE) -C policy.2.3.FSharp.Core $@
 	$(MAKE) -C policy.3.3.FSharp.Core $@
 	$(MAKE) -C policy.3.7.FSharp.Core $@
 	$(MAKE) -C policy.3.47.FSharp.Core $@
 	$(MAKE) -C policy.3.78.FSharp.Core $@
 	$(MAKE) -C policy.3.259.FSharp.Core $@
+	$(MAKE) -C policy.4.0.FSharp.Core $@
 	$(MAKE) -C policy.4.3.FSharp.Core $@
-	$(MAKE) -C policy.2.0.FSharp.Core TargetFramework=net20 $@
-	$(MAKE) -C policy.2.3.FSharp.Core TargetFramework=net20 $@
 	if test -e $MONOGACDIR20/mscorlib.dll; then $(MAKE) -C FSharp.Core TargetFramework=net20 $@;fi
 	$(MAKE) only-monotouch only-monodroid only-xamarinmac
 	$(MAKE) -C FSharp.Core FSharpCoreBackVersion=3.0 TargetFramework=net40 $@

--- a/src/fsharp/policy.2.0.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.2.0.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.2.0.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.2.3.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.2.3.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.2.3.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.3.259.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.259.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.3.259.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.3.3.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.3.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.3.3.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.3.47.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.47.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.3.47.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.3.7.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.7.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.3.7.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.3.78.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.78.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.3.78.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.4.0.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.4.0.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.4.0.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/src/fsharp/policy.4.3.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.4.3.FSharp.Core/Makefile.in
@@ -1,6 +1,7 @@
 NAME=policy.4.3.FSharp.Core
 ASSEMBLY = $(NAME).dll
 DELAY_SIGN=1
+TOKEN=$(FSCORE_DELAY_SIGN_TOKEN)
 
 srcdir := @abs_srcdir@/
 

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net40/App.config
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net40/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+  </startup>
+</configuration>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net40/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net40/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Console_App_net40.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Console_App_net40")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Console_App_net40")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("fb1619a2-05ef-4599-90e0-29e6ad469b1b")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Program.fs
@@ -1,0 +1,7 @@
+﻿// Learn more about F# at http://fsharp.org
+// See the 'F# Tutorial' project for more help.
+
+[<EntryPoint>]
+let main argv = 
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Sample_VS2015_FSharp_Console_App_net40.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Sample_VS2015_FSharp_Console_App_net40.fsproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>fb1619a2-05ef-4599-90e0-29e6ad469b1b</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Console_App_net40</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Console_App_net40</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>Sample_VS2015_FSharp_Console_App_net40</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Console_App_net40.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Console_App_net40.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Sample_VS2015_FSharp_Console_App_net40.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net40/Sample_VS2015_FSharp_Console_App_net40.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Console_App_net40", "Sample_VS2015_FSharp_Console_App_net40.fsproj", "{FB1619A2-05EF-4599-90E0-29E6AD469B1B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FB1619A2-05EF-4599-90E0-29E6AD469B1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB1619A2-05EF-4599-90E0-29E6AD469B1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB1619A2-05EF-4599-90E0-29E6AD469B1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB1619A2-05EF-4599-90E0-29E6AD469B1B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net45/App.config
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net45/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net45/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net45/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Console_App_net45.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Console_App_net45")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Console_App_net45")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("b92ebe2e-23f6-49b2-9e79-f1104de1ddeb")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Program.fs
@@ -1,0 +1,7 @@
+﻿// Learn more about F# at http://fsharp.org
+// See the 'F# Tutorial' project for more help.
+
+[<EntryPoint>]
+let main argv = 
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Sample_VS2015_FSharp_Console_App_net45.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Sample_VS2015_FSharp_Console_App_net45.fsproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>b92ebe2e-23f6-49b2-9e79-f1104de1ddeb</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Console_App_net45</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Console_App_net45</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <Name>Sample_VS2015_FSharp_Console_App_net45</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Console_App_net45.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Console_App_net45.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Sample_VS2015_FSharp_Console_App_net45.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net45/Sample_VS2015_FSharp_Console_App_net45.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Console_App_net45", "Sample_VS2015_FSharp_Console_App_net45.fsproj", "{B92EBE2E-23F6-49B2-9E79-F1104DE1DDEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B92EBE2E-23F6-49B2-9E79-F1104DE1DDEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B92EBE2E-23F6-49B2-9E79-F1104DE1DDEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B92EBE2E-23F6-49B2-9E79-F1104DE1DDEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B92EBE2E-23F6-49B2-9E79-F1104DE1DDEB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net451/App.config
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net451/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+  </startup>
+</configuration>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net451/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net451/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Console_App_net451.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Console_App_net451")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Console_App_net451")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("361d29d1-5896-446b-a9f5-59f7f25cddc2")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Program.fs
@@ -1,0 +1,7 @@
+﻿// Learn more about F# at http://fsharp.org
+// See the 'F# Tutorial' project for more help.
+
+[<EntryPoint>]
+let main argv = 
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Sample_VS2015_FSharp_Console_App_net451.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Sample_VS2015_FSharp_Console_App_net451.fsproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>361d29d1-5896-446b-a9f5-59f7f25cddc2</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Console_App_net451</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Console_App_net451</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <Name>Sample_VS2015_FSharp_Console_App_net451</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Console_App_net451.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Console_App_net451.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Sample_VS2015_FSharp_Console_App_net451.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net451/Sample_VS2015_FSharp_Console_App_net451.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Console_App_net451", "Sample_VS2015_FSharp_Console_App_net451.fsproj", "{361D29D1-5896-446B-A9F5-59F7F25CDDC2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{361D29D1-5896-446B-A9F5-59F7F25CDDC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{361D29D1-5896-446B-A9F5-59F7F25CDDC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{361D29D1-5896-446B-A9F5-59F7F25CDDC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{361D29D1-5896-446B-A9F5-59F7F25CDDC2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net452/App.config
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net452/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+</configuration>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net452/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net452/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Console_App_net452.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Console_App_net452")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Console_App_net452")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("61501d08-5718-43f0-b0e6-39da0b7ac4a9")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Program.fs
@@ -1,0 +1,7 @@
+﻿// Learn more about F# at http://fsharp.org
+// See the 'F# Tutorial' project for more help.
+
+[<EntryPoint>]
+let main argv = 
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Sample_VS2015_FSharp_Console_App_net452.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Sample_VS2015_FSharp_Console_App_net452.fsproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>61501d08-5718-43f0-b0e6-39da0b7ac4a9</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Console_App_net452</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Console_App_net452</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <Name>Sample_VS2015_FSharp_Console_App_net452</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Console_App_net452.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Console_App_net452.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Sample_VS2015_FSharp_Console_App_net452.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net452/Sample_VS2015_FSharp_Console_App_net452.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Console_App_net452", "Sample_VS2015_FSharp_Console_App_net452.fsproj", "{61501D08-5718-43F0-B0E6-39DA0B7AC4A9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{61501D08-5718-43F0-B0E6-39DA0B7AC4A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61501D08-5718-43F0-B0E6-39DA0B7AC4A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61501D08-5718-43F0-B0E6-39DA0B7AC4A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61501D08-5718-43F0-B0E6-39DA0B7AC4A9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net46/App.config
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net46/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
+</configuration>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net46/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net46/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Console_App_net46.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Console_App_net46")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Console_App_net46")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("acb52518-8086-448d-bf0a-eab1c2cf852f")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Program.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Program.fs
@@ -1,0 +1,7 @@
+﻿// Learn more about F# at http://fsharp.org
+// See the 'F# Tutorial' project for more help.
+
+[<EntryPoint>]
+let main argv = 
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Sample_VS2015_FSharp_Console_App_net46.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Sample_VS2015_FSharp_Console_App_net46.fsproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>acb52518-8086-448d-bf0a-eab1c2cf852f</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Console_App_net46</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Console_App_net46</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <Name>Sample_VS2015_FSharp_Console_App_net46</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Console_App_net46.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Console_App_net46.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Sample_VS2015_FSharp_Console_App_net46.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Console_App_net46/Sample_VS2015_FSharp_Console_App_net46.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Console_App_net46", "Sample_VS2015_FSharp_Console_App_net46.fsproj", "{ACB52518-8086-448D-BF0A-EAB1C2CF852F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ACB52518-8086-448D-BF0A-EAB1C2CF852F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACB52518-8086-448D-BF0A-EAB1C2CF852F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACB52518-8086-448D-BF0A-EAB1C2CF852F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACB52518-8086-448D-BF0A-EAB1C2CF852F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Library_net40/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net40/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Library_net40.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Library_net40")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Library_net40")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("38fe8d84-4720-4089-9dfc-2a3bcf1b24e7")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Library_net40/Library1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net40/Library1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Library_net40
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net40/Sample_VS2015_FSharp_Library_net40.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net40/Sample_VS2015_FSharp_Library_net40.fsproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>38fe8d84-4720-4089-9dfc-2a3bcf1b24e7</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Library_net40</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Library_net40</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Library_net40</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Library_net40.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Library_net40.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Library1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Library_net40/Sample_VS2015_FSharp_Library_net40.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net40/Sample_VS2015_FSharp_Library_net40.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Library_net40", "Sample_VS2015_FSharp_Library_net40.fsproj", "{38FE8D84-4720-4089-9DFC-2A3BCF1B24E7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{38FE8D84-4720-4089-9DFC-2A3BCF1B24E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38FE8D84-4720-4089-9DFC-2A3BCF1B24E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38FE8D84-4720-4089-9DFC-2A3BCF1B24E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38FE8D84-4720-4089-9DFC-2A3BCF1B24E7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Library_net40/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net40/Script.fsx
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "Library1.fs"
+open Sample_VS2015_FSharp_Library_net40
+
+// Define your library scripting code here
+

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Library_net45.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Library_net45")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Library_net45")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("7114eb5b-c1e0-476a-b384-25bb209df8ae")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45/Library1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45/Library1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Library_net45
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45/Sample_VS2015_FSharp_Library_net45.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45/Sample_VS2015_FSharp_Library_net45.fsproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>7114eb5b-c1e0-476a-b384-25bb209df8ae</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Library_net45</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Library_net45</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Library_net45</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Library_net45.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Library_net45.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Library1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45/Sample_VS2015_FSharp_Library_net45.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45/Sample_VS2015_FSharp_Library_net45.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Library_net45", "Sample_VS2015_FSharp_Library_net45.fsproj", "{7114EB5B-C1E0-476A-B384-25BB209DF8AE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7114EB5B-C1E0-476A-B384-25BB209DF8AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7114EB5B-C1E0-476A-B384-25BB209DF8AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7114EB5B-C1E0-476A-B384-25BB209DF8AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7114EB5B-C1E0-476A-B384-25BB209DF8AE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45/Script.fsx
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "Library1.fs"
+open Sample_VS2015_FSharp_Library_net45
+
+// Define your library scripting code here
+

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Library_net45_fsharp_30.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Library_net45_fsharp_30")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Library_net45_fsharp_30")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("d2da9cc5-3e34-4b14-86ac-ef468a8dc64b")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Library1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Library1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Library_net45_fsharp_30
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Sample_VS2015_FSharp_Library_net45_fsharp_30.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Sample_VS2015_FSharp_Library_net45_fsharp_30.fsproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>d2da9cc5-3e34-4b14-86ac-ef468a8dc64b</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Library_net45_fsharp_30</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Library_net45_fsharp_30</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Library_net45_fsharp_30</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Library_net45_fsharp_30.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Library_net45_fsharp_30.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Library1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Sample_VS2015_FSharp_Library_net45_fsharp_30.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Sample_VS2015_FSharp_Library_net45_fsharp_30.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Library_net45_fsharp_30", "Sample_VS2015_FSharp_Library_net45_fsharp_30.fsproj", "{D2DA9CC5-3E34-4B14-86AC-EF468A8DC64B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D2DA9CC5-3E34-4B14-86AC-EF468A8DC64B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2DA9CC5-3E34-4B14-86AC-EF468A8DC64B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2DA9CC5-3E34-4B14-86AC-EF468A8DC64B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2DA9CC5-3E34-4B14-86AC-EF468A8DC64B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_30/Script.fsx
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "Library1.fs"
+open Sample_VS2015_FSharp_Library_net45_fsharp_30
+
+// Define your library scripting code here
+

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Sample_VS2015_FSharp_Library_net45_fsharp_31.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Library_net45_fsharp_31")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Library_net45_fsharp_31")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("9a5f1c40-a185-429a-b1aa-f43c8b839e6a")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Library1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Library1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Library_net45_fsharp_31
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Sample_VS2015_FSharp_Library_net45_fsharp_31.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Sample_VS2015_FSharp_Library_net45_fsharp_31.fsproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>9a5f1c40-a185-429a-b1aa-f43c8b839e6a</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Library_net45_fsharp_31</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Library_net45_fsharp_31</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Library_net45_fsharp_31</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Library_net45_fsharp_31.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Library_net45_fsharp_31.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Library1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Sample_VS2015_FSharp_Library_net45_fsharp_31.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Sample_VS2015_FSharp_Library_net45_fsharp_31.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Library_net45_fsharp_31", "Sample_VS2015_FSharp_Library_net45_fsharp_31.fsproj", "{9A5F1C40-A185-429A-B1AA-F43C8B839E6A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9A5F1C40-A185-429A-B1AA-F43C8B839E6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A5F1C40-A185-429A-B1AA-F43C8B839E6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A5F1C40-A185-429A-B1AA-F43C8B839E6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A5F1C40-A185-429A-B1AA-F43C8B839E6A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Library_net45_fsharp_31/Script.fsx
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "Library1.fs"
+open Sample_VS2015_FSharp_Library_net45_fsharp_31
+
+// Define your library scripting code here
+

--- a/tests/projects/Sample_VS2015_FSharp_Portable259_Library/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable259_Library/AssemblyInfo.fs
@@ -1,0 +1,35 @@
+﻿namespace Sample_VS2015_FSharp_Portable259_Library.AssemblyInfo
+
+open System.Resources
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Portable259_Library")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Portable259_Library")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+[<assembly: NeutralResourcesLanguage("en")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Portable259_Library/PortableLibrary1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable259_Library/PortableLibrary1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Portable259_Library
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Sample_VS2015_FSharp_Portable259_Library.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Sample_VS2015_FSharp_Portable259_Library.fsproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>a7f12d45-4552-4d8a-a3da-cb4a4e40db58</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Portable259_Library</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Portable259_Library</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetProfile>netcore</TargetProfile>
+    <TargetFSharpCoreVersion>3.259.4.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Portable259_Library</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Portable259_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Portable259_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <Name>FSharp.Core</Name>
+      <AssemblyName>FSharp.Core.dll</AssemblyName>
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="PortableLibrary1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">12</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Sample_VS2015_FSharp_Portable259_Library.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Sample_VS2015_FSharp_Portable259_Library.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Portable259_Library", "Sample_VS2015_FSharp_Portable259_Library.fsproj", "{A7F12D45-4552-4D8A-A3DA-CB4A4E40DB58}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7F12D45-4552-4D8A-A3DA-CB4A4E40DB58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7F12D45-4552-4D8A-A3DA-CB4A4E40DB58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7F12D45-4552-4D8A-A3DA-CB4A4E40DB58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7F12D45-4552-4D8A-A3DA-CB4A4E40DB58}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable259_Library/Script.fsx
@@ -1,0 +1,6 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "PortableLibrary1.fs"
+open Sample_VS2015_FSharp_Portable259_Library
+

--- a/tests/projects/Sample_VS2015_FSharp_Portable47_Library/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable47_Library/AssemblyInfo.fs
@@ -1,0 +1,35 @@
+﻿namespace Sample_VS2015_FSharp_Portable47_Library.AssemblyInfo
+
+open System.Resources
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Portable47_Library")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Portable47_Library")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+[<assembly: NeutralResourcesLanguage("en")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Portable47_Library/PortableLibrary1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable47_Library/PortableLibrary1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Portable47_Library
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Sample_VS2015_FSharp_Portable47_Library.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Sample_VS2015_FSharp_Portable47_Library.fsproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>4bd1abac-55f2-4ae6-b562-fe68ee86134d</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Portable47_Library</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Portable47_Library</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile47</TargetFrameworkProfile>
+    <TargetFSharpCoreVersion>3.47.4.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Portable47_Library</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Portable47_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Portable47_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <Name>FSharp.Core</Name>
+      <AssemblyName>FSharp.Core.dll</AssemblyName>
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETPortable\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="PortableLibrary1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Sample_VS2015_FSharp_Portable47_Library.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Sample_VS2015_FSharp_Portable47_Library.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Portable47_Library", "Sample_VS2015_FSharp_Portable47_Library.fsproj", "{4BD1ABAC-55F2-4AE6-B562-FE68EE86134D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4BD1ABAC-55F2-4AE6-B562-FE68EE86134D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BD1ABAC-55F2-4AE6-B562-FE68EE86134D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BD1ABAC-55F2-4AE6-B562-FE68EE86134D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BD1ABAC-55F2-4AE6-B562-FE68EE86134D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable47_Library/Script.fsx
@@ -1,0 +1,6 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "PortableLibrary1.fs"
+open Sample_VS2015_FSharp_Portable47_Library
+

--- a/tests/projects/Sample_VS2015_FSharp_Portable78_Library/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable78_Library/AssemblyInfo.fs
@@ -1,0 +1,35 @@
+﻿namespace Sample_VS2015_FSharp_Portable78_Library.AssemblyInfo
+
+open System.Resources
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Portable78_Library")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Portable78_Library")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+[<assembly: NeutralResourcesLanguage("en")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Portable78_Library/PortableLibrary1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable78_Library/PortableLibrary1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Portable78_Library
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Sample_VS2015_FSharp_Portable78_Library.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Sample_VS2015_FSharp_Portable78_Library.fsproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>a5bbc2b7-8130-49e1-af64-8fdb3c1d6f00</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Portable78_Library</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Portable78_Library</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetProfile>netcore</TargetProfile>
+    <TargetFSharpCoreVersion>3.78.4.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Portable78_Library</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Portable78_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Portable78_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <Name>FSharp.Core</Name>
+      <AssemblyName>FSharp.Core.dll</AssemblyName>
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="PortableLibrary1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">12</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Sample_VS2015_FSharp_Portable78_Library.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Sample_VS2015_FSharp_Portable78_Library.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Portable78_Library", "Sample_VS2015_FSharp_Portable78_Library.fsproj", "{A5BBC2B7-8130-49E1-AF64-8FDB3C1D6F00}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5BBC2B7-8130-49E1-AF64-8FDB3C1D6F00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5BBC2B7-8130-49E1-AF64-8FDB3C1D6F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5BBC2B7-8130-49E1-AF64-8FDB3C1D6F00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5BBC2B7-8130-49E1-AF64-8FDB3C1D6F00}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable78_Library/Script.fsx
@@ -1,0 +1,6 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "PortableLibrary1.fs"
+open Sample_VS2015_FSharp_Portable78_Library
+

--- a/tests/projects/Sample_VS2015_FSharp_Portable7_Library/AssemblyInfo.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable7_Library/AssemblyInfo.fs
@@ -1,0 +1,35 @@
+﻿namespace Sample_VS2015_FSharp_Portable7_Library.AssemblyInfo
+
+open System.Resources
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Sample_VS2015_FSharp_Portable7_Library")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Sample_VS2015_FSharp_Portable7_Library")>]
+[<assembly: AssemblyCopyright("Copyright ©  2015")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+[<assembly: NeutralResourcesLanguage("en")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/tests/projects/Sample_VS2015_FSharp_Portable7_Library/PortableLibrary1.fs
+++ b/tests/projects/Sample_VS2015_FSharp_Portable7_Library/PortableLibrary1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_VS2015_FSharp_Portable7_Library
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Sample_VS2015_FSharp_Portable7_Library.fsproj
+++ b/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Sample_VS2015_FSharp_Portable7_Library.fsproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>fd3dae06-92b6-4bb6-8609-85c9d9c904ec</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Sample_VS2015_FSharp_Portable7_Library</RootNamespace>
+    <AssemblyName>Sample_VS2015_FSharp_Portable7_Library</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetProfile>netcore</TargetProfile>
+    <TargetFSharpCoreVersion>3.7.4.0</TargetFSharpCoreVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Name>Sample_VS2015_FSharp_Portable7_Library</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Debug\Sample_VS2015_FSharp_Portable7_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\Sample_VS2015_FSharp_Portable7_Library.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FSharp.Core">
+      <Name>FSharp.Core</Name>
+      <AssemblyName>FSharp.Core.dll</AssemblyName>
+      <HintPath>$(MSBuildExtensionsPath32)\..\Reference Assemblies\Microsoft\FSharp\.NETCore\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="PortableLibrary1.fs" />
+    <None Include="Script.fsx" />
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">12</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.Portable.FSharp.Targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Sample_VS2015_FSharp_Portable7_Library.sln
+++ b/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Sample_VS2015_FSharp_Portable7_Library.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample_VS2015_FSharp_Portable7_Library", "Sample_VS2015_FSharp_Portable7_Library.fsproj", "{FD3DAE06-92B6-4BB6-8609-85C9D9C904EC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FD3DAE06-92B6-4BB6-8609-85C9D9C904EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD3DAE06-92B6-4BB6-8609-85C9D9C904EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD3DAE06-92B6-4BB6-8609-85C9D9C904EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD3DAE06-92B6-4BB6-8609-85C9D9C904EC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Script.fsx
+++ b/tests/projects/Sample_VS2015_FSharp_Portable7_Library/Script.fsx
@@ -1,0 +1,6 @@
+﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
+// for more guidance on F# programming.
+
+#load "PortableLibrary1.fs"
+open Sample_VS2015_FSharp_Portable7_Library
+

--- a/tests/projects/build.sh
+++ b/tests/projects/build.sh
@@ -20,6 +20,18 @@
 (cd Sample_VS2012_FSharp_ConsoleApp_net40_upgraded_VS2013 && xbuild) &&
 (cd Sample_VS2012_FSharp_Portable_Library_upgraded_2013 && xbuild) &&
 (cd Sample_VS2013_FSharp_Portable_Library_net451_adjusted_to_profile78 && xbuild) &&
+(cd Sample_VS2015_FSharp_Console_App_net40 && xbuild) &&
+(cd Sample_VS2015_FSharp_Console_App_net45 && xbuild) &&
+(cd Sample_VS2015_FSharp_Console_App_net451 && xbuild) &&
+(cd Sample_VS2015_FSharp_Console_App_net452 && xbuild) &&
+(cd Sample_VS2015_FSharp_Library_net40 && xbuild) &&
+(cd Sample_VS2015_FSharp_Library_net45 && xbuild) &&
+(cd Sample_VS2015_FSharp_Library_net45_fsharp_30 && xbuild) &&
+(cd Sample_VS2015_FSharp_Library_net45_fsharp_31 && xbuild) &&
+(cd Sample_VS2015_FSharp_Portable7_Library && xbuild) &&
+(cd Sample_VS2015_FSharp_Portable47_Library && xbuild) &&
+(cd Sample_VS2015_FSharp_Portable78_Library && xbuild) &&
+(cd Sample_VS2015_FSharp_Portable259_Library && xbuild) &&
 echo "all projects built successfully"
 
 


### PR DESCRIPTION
Various problems with the install

* the -package argument is empty for policy DLLs:

```
       Installing /home/travis/build/fsharp/fsharp/lib/release/net20/policy.2.0.FSharp.Core.dll into GAC root /usr/lib/ as package 
       Option -package takes 1 argument
```

* the backversion FSharp.Core DLLs are overriding the install of FSharp.Core .NET 4.5

```
       Installing /home/travis/build/fsharp/fsharp/lib/release/fsharp30/net40/FSharp.Core.dll into GAC root /usr/lib/ as package 4.5
       Package exported to: /usr/lib/mono/4.5/FSharp.Core.dll -> ../gac/FSharp.Core/4.3.0.0__b03f5f7f11d50a3a/FSharp.Core.dll
       Installed /home/travis/build/fsharp/fsharp/lib/release/fsharp30/net40/FSharp.Core.dll into the gac (/usr/lib/mono/gac)
```

* the .NET 2.0 and 4.0 FSharp.Core DLLs are not being placed in ``.../Reference Assemblies/Microsoft/FSharp/.NETFramework/...``. We may as well place them there

