### PR TITLE
Do not depend on Mono executables being in the PATH, but use prefix a…

### DIFF
--- a/config.make.in
+++ b/config.make.in
@@ -4,6 +4,7 @@ topdir := @abs_top_srcdir@/
 builddir := @abs_top_builddir@/
 libdir := ${prefix}/lib/
 bindir := ${prefix}/bin/
+monobindir := @MONOBINDIR@
 monolibdir := @MONOLIBDIR@
 monogacdir := @MONOGACDIR@
 

--- a/configure.ac
+++ b/configure.ac
@@ -9,9 +9,13 @@ AC_PROG_MAKE_SET
 
 AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
 
-# On OSX use Mono's private copy of pkg-config if it exists, see https://github.com/fsharp/fsharp/issues/107
+# pkg-config precedence: 1) our prefix 2) the system Mono location 3) the PATH
+prefix_pkg_config="$prefix"/bin/pkg-config
 osx_pkg_config=/Library/Frameworks/Mono.framework/Versions/Current/bin/pkg-config
-if test -e $osx_pkg_config; then
+
+if test -e $prefix_pkg_config; then
+    PKG_CONFIG=$prefix_pkg_config
+elif test -e $osx_pkg_config; then
     PKG_CONFIG=$osx_pkg_config
 elif test "x$PKG_CONFIG" = "xno"; then
         AC_MSG_ERROR([You need to install pkg-config])
@@ -19,18 +23,6 @@ fi
 
 AC_MSG_NOTICE("pkg-config: $PKG_CONFIG")
 AC_MSG_NOTICE("PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR")
-
-# On OSX El Capitan, xbuild is no longer in PATH, so we need to use the full path.
-AC_PATH_PROG(XBUILD, xbuild, no)
-osx_xbuild=/Library/Frameworks/Mono.framework/Versions/Current/bin/xbuild
-if test "x$XBUILD" == "xno"; then
-  if test -e $osx_xbuild; then
-    XBUILD=$osx_xbuild
-  else
-    AC_MSG_ERROR([Could not find xbuild])
-  fi
-fi
-AC_MSG_NOTICE(xbuild: $XBUILD)
 
 MONO_REQUIRED_VERSION=3.0
 MONO_RECOMMENDED_VERSION=3.2
@@ -64,7 +56,18 @@ AC_ARG_WITH([gacdir],
         )
 
 MONOPREFIX=$(cd `$PKG_CONFIG --variable=prefix mono` && pwd)
+MONOBINDIR="$MONOPREFIX"/bin
 MONOLIBDIR="$MONOPREFIX"/lib
+
+AC_PATH_PROG(XBUILD, xbuild, no)
+xbuild_from_pkg_config="$MONOBINDIR"/xbuild
+if test -e $xbuild_from_pkg_config; then
+    XBUILD=$xbuild_from_pkg_config
+elif test "x$XBUILD" == "xno"; then
+    AC_MSG_ERROR([Could not find xbuild])
+fi
+AC_MSG_NOTICE(xbuild: $XBUILD)
+
 MONOGACDIR="$MONOLIBDIR"/mono
 if ! test "x$with_gacdir" = "xno"; then
 	MONOGACDIR=$(cd "$with_gacdir/.." && pwd)
@@ -138,6 +141,7 @@ AC_SUBST(MONOTOUCHENABLED)
 AC_SUBST(MONODROIDENABLED)
 AC_SUBST(XAMARINMACENABLED)
 
+AC_SUBST(MONOBINDIR)
 AC_SUBST(MONOLIBDIR)
 AC_SUBST(MONOGACDIR)
 

--- a/launcher.in
+++ b/launcher.in
@@ -21,4 +21,4 @@ fi
 # location of the default FSharp install in order to find the FSharp compiler binaries (see 
 # fsharpbinding/MonoDevelop.FSharpBinding/Services/CompilerLocationUtils.fs). That's a pretty unfortunate
 # way of finding those binaries. And really should be changed.
-$EXEC mono $DEBUG $MONO_OPTIONS @DIR@/@TOOL@ --exename:$(basename "$0") "$@"
+$EXEC @MONOBINDIR@/mono $DEBUG $MONO_OPTIONS @DIR@/@TOOL@ --exename:$(basename "$0") "$@"

--- a/src/fsharp/policy.2.0.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.2.0.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.2.3.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.2.3.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.3.259.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.259.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.3.3.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.3.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.3.47.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.47.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.3.7.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.7.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.3.78.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.3.78.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.4.0.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.4.0.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/policy.4.3.FSharp.Core/Makefile.in
+++ b/src/fsharp/policy.4.3.FSharp.Core/Makefile.in
@@ -14,7 +14,7 @@ include $(topdir)/src/fsharp/targets.make
 $(outdir)/$(NAME).dll: $(NAME).dll.config 
 	@mkdir -p $(@D)
 	cp $(NAME).dll.config $(@D)
-	al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
+	$(monobindir)/al /link:$(NAME).dll.config /out:$@ /delaysign /keyfile:$(topdir)msfinal.pub
 
 build: 
 	$(MAKE) $(outdir)/$(NAME).dll

--- a/src/fsharp/targets.make
+++ b/src/fsharp/targets.make
@@ -41,7 +41,7 @@ install-lib:
 	@mkdir -p $(DESTDIR)$(gacdir)/$(TARGET)
 	@if test "x$(DELAY_SIGN)" = "x1"; then \
 	    echo "Signing $(outdir)$(ASSEMBLY) with Mono key"; \
-	    sn -q -R $(outdir)$(ASSEMBLY) $(srcdir)../../../mono.snk; \
+	    $(monobindir)/sn -q -R $(outdir)$(ASSEMBLY) $(srcdir)../../../mono.snk; \
 	fi
 	@if test x-$(NAME) = x-FSharp.Build; then \
 	    echo "Installing Microsoft.FSharp.Targets and Microsoft.Portable.FSharp.Targets into install locations matching Visual Studio"; \
@@ -99,7 +99,7 @@ install-lib:
 	    if test -e $(outdir)$(NAME).dll; then \
 			if test x-$(PKGINSTALL) = x-yes; then \
 				echo "Using gacutil to install $(outdir)$(ASSEMBLY) into GAC root $(DESTDIR)$(libdir) as package $(TARGET)"; \
-				gacutil -i $(outdir)$(ASSEMBLY) -root $(DESTDIR)$(libdir) -package $(TARGET); \
+				$(monobindir)/gacutil -i $(outdir)$(ASSEMBLY) -root $(DESTDIR)$(libdir) -package $(TARGET); \
 			else \
 				echo "Installing $(outdir)$(NAME).dll to $(DESTDIR)$(gacdir)/gac/$(NAME)/$(VERSION)__$(TOKEN)/"; \
 				mkdir -p $(DESTDIR)$(gacdir)/gac/$(NAME)/$(VERSION)__$(TOKEN)/; \
@@ -186,7 +186,7 @@ install-lib-net40:
 # This also installs 'fsharpc' and 'fsharpi'
 install-bin:
 	chmod +x $(outdir)$(ASSEMBLY)
-	sed -e 's,[@]DIR[@],$(gacdir)/$(TARGET),g' -e 's,[@]TOOL[@],$(ASSEMBLY),g' < $(topdir)launcher > $(outdir)$(subst fs,fsharp,$(NAME))
+	sed -e 's,[@]DIR[@],$(gacdir)/$(TARGET),g' -e 's,[@]TOOL[@],$(ASSEMBLY),g' -e 's,[@]MONOBINDIR[@],$(monobindir),g' < $(topdir)launcher > $(outdir)$(subst fs,fsharp,$(NAME))
 	chmod +x $(outdir)$(subst fs,fsharp,$(NAME))
 	@mkdir -p $(DESTDIR)$(gacdir)/$(TARGET)
 	@mkdir -p $(DESTDIR)$(bindir)


### PR DESCRIPTION
…nd system Mono paths to resolve them. Fixes El Capitan build issues.

The symlinks for the system Mono executables are installed in /usr/local/bin starting from OS X El Capitan, and we may no longer rely on them being part of the user's PATH. These changes prioritize using pkg-config to resolve their path, and look for pkg-config itself first in the F# install prefix, and then at the system Mono location. PATH is last resort.

This also properly isolates parallel installations from system Mono.