### PR TITLE
Travis multiarch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: csharp
 
+os:
+  - linux
+  - osx
+
+mono:
+  - latest
+
 install:
 
 script: 
-  - ./autogen.sh   --prefix=/usr
+  - ./autogen.sh
   - make 
   - sudo make install
   - xbuild ./src/fsharp-library-unittests-build.proj /p:TargetFramework=net40 /p:Configuration=Release
   - (cd tests/projects; ./build.sh)
   - (cd tests/fsharp/core; ./run-opt.sh)
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ mono:
 
 install:
 
+before_script:
+  - chmod +x travis-autogen.sh
+
 script: 
   - ./travis-autogen.sh
   - make 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ mono:
 install:
 
 script: 
-  - ./autogen.sh
+  - ./travis-autogen.sh
   - make 
   - sudo make install
   - xbuild ./src/fsharp-library-unittests-build.proj /p:TargetFramework=net40 /p:Configuration=Release

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -30,3 +30,4 @@ function pack($nuspec){
 
 pack(gi .\FSharp.Core.Nuget\FSharp.Core.nuspec)
 pack(gi .\FSharp.Compiler.Tools.Nuget\FSharp.Compiler.Tools.nuspec)
+

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,4 @@
 #!/usr/bin/env sh
 
-if [[ $TRAVIS_OS_NAME == osx ]]; 
-	then 
-		monoVer=$(mono --version | head -n 1 | cut -d' ' -f 5)
-		prefix="/Library/Frameworks/Mono.framework/Versions/$monoVer"; 
-	else prefix="/usr"; 
-fi
-
 which autoreconf > /dev/null || (echo "Please install autoconf" && exit 1)
-autoreconf && ./configure --prefix=$prefix
+autoreconf && ./configure $@

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env sh
+
+if [[ $TRAVIS_OS_NAME == osx ]]; 
+	then 
+		monoVer=$(mono --version | head -n 1 | cut -d' ' -f 5)
+		prefix="/Library/Frameworks/Mono.framework/Versions/$monoVer"; 
+	else prefix="/usr"; 
+fi
+
 which autoreconf > /dev/null || (echo "Please install autoconf" && exit 1)
-autoreconf && ./configure $@
+autoreconf && ./configure --prefix=$prefix

--- a/travis-autogen.sh
+++ b/travis-autogen.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+if [[ $TRAVIS_OS_NAME == osx ]];
+    then
+        monoVer=$(mono --version | head -n 1 | cut -d' ' -f 5)
+        prefix="/Library/Frameworks/Mono.framework/Versions/$monoVer";
+    else prefix="/usr";
+fi
+
+./autogen.sh --prefix=$prefix

--- a/travis-autogen.sh
+++ b/travis-autogen.sh
@@ -4,7 +4,8 @@ if [[ $TRAVIS_OS_NAME == osx ]];
     then
         monoVer=$(mono --version | head -n 1 | cut -d' ' -f 5)
         prefix="/Library/Frameworks/Mono.framework/Versions/$monoVer";
-    else prefix="/usr";
+    else 
+    	prefix="/usr";
 fi
 
 ./autogen.sh --prefix=$prefix


### PR DESCRIPTION
This PR enables the build on Travis CI to target multiple OS's and mono versions.

You can look at builds [here](https://travis-ci.org/baronfel/fsharp), though right now they are breaking because of a test that I need to look into.

This would address #499 