### PR TITLE
allow failures on mono latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ script:
   - xbuild ./src/fsharp-library-unittests-build.proj /p:TargetFramework=net40 /p:Configuration=Release
   - (cd tests/projects; ./build.sh)
   - (cd tests/fsharp/core; ./run-opt.sh)
+
+matrix:
+  allow_failures:
+    - mono: latest


### PR DESCRIPTION
we should always build and test with latest mono, but it may break the build sometimes, it's ok

if a `Mono: latest` build job fails ( both osx and linux ) the build should not fail

with this, we dont need to disable tests ( like #518 ) and we know when the problem is fixed

see this pr travis build

![allow_failures](https://cloud.githubusercontent.com/assets/147243/11532442/17032b18-9904-11e5-8bc4-149d1e8ae8d5.PNG)
