### PR TITLE
Assume we are inside XBuild when 4.5/Mono.Posix.dll exists

### DIFF
--- a/lib/bootstrap/4.0/Microsoft.FSharp.Targets
+++ b/lib/bootstrap/4.0/Microsoft.FSharp.Targets
@@ -68,7 +68,7 @@ Copyright (C) Microsoft Corporation. Apache 2.0 License.
 
   <PropertyGroup>
     <UsingXBuild>false</UsingXBuild>
-    <UsingXBuild Condition="Exists('$(MSBuildExtensionsPath32)\..\4.0\Mono.Posix.dll')">true</UsingXBuild>
+    <UsingXBuild Condition="$(MSBuildExtensionsPath32.Contains('xbuild'))">true</UsingXBuild>
   </PropertyGroup>
 
   

--- a/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/fsharp/FSharp.Build/Microsoft.FSharp.Targets
@@ -68,7 +68,7 @@ Copyright (C) Microsoft Corporation. Apache 2.0 License.
 
   <PropertyGroup>
     <UsingXBuild>false</UsingXBuild>
-    <UsingXBuild Condition="Exists('$(MSBuildExtensionsPath32)\..\4.0\Mono.Posix.dll')">true</UsingXBuild>
+    <UsingXBuild Condition="$(MSBuildExtensionsPath32.Contains('xbuild'))">true</UsingXBuild>
   </PropertyGroup>
 
     <Target


### PR DESCRIPTION
4.0/Mono.Posix.dll is not guaranteed to exist, on Mono 4.0+