### PR TITLE
Update array.fs

### DIFF
--- a/src/fsharp/FSharp.Core/array.fs
+++ b/src/fsharp/FSharp.Core/array.fs
@@ -384,7 +384,7 @@ namespace Microsoft.FSharp.Collections
             checkNonNull "array" array
             let len = array.Length
             let rec loop i = i < len && (f array.[i] || loop (i+1))
-            loop 0
+            len > 0 && loop 0
 
         [<CompiledName("Contains")>]
         let inline contains e (array:'T[]) =


### PR DESCRIPTION
There may be a missing length check on exists, as without hte length check the cost of a comparison and a `call` is incurred.

Adding the simple len > 0 check before the loop appears (in the basic cases I have tested) to near triple performance.
```
let f arr = 
    Array.exists (fun e -> e = true) arr

for i in 0..60000000 do f ([||]:bool []) ;; // 1.8 seconds

let f2 arr = 
    if Array.length arr > 0 then
        Array.exists (fun e -> e = true) arr
    else 
        false

for i in 0..60000000 do f2 ([||]:bool []) ;; // 0.430 seconds
```

Note: this is something I have found an isolated instance of, it may be appropriate to ensure that such checks (if they are required, I can only speak for my use case) are consistant accross other modules, such as Seq\List.