### PR TITLE
Could not open FSharp.Tests

### DIFF
--- a/src/fsharp/FSharp.Core.Unittests/FSharp.Core.UnitTests.TestApp.csproj
+++ b/src/fsharp/FSharp.Core.Unittests/FSharp.Core.UnitTests.TestApp.csproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <FSharpSourcesRoot>..\..</FSharpSourcesRoot>
+    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..</FSharpSourcesRoot>
   </PropertyGroup>
   <PropertyGroup>
     <NUnit>$(FSharpSourcesRoot)\..\tools\nUnit.Silverlight</NUnit>

--- a/tests/fsharp/FSharp.Tests.fsproj
+++ b/tests/fsharp/FSharp.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <FSharpSourcesRoot>..\..\src</FSharpSourcesRoot>
+    <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..\src\</FSharpSourcesRoot>
     <ProjectGuid>{C163E892-5BF7-4B59-AA99-B0E8079C67C4}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.Settings.targets" />


### PR DESCRIPTION
Normalized FSharpSourcesRoot logic in order to be able to open project "FSharp.Tests" in visual studio.
