### PR TITLE
Allow failures in Mono 4.2.2 but not latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ script:
 matrix:
   allow_failures:
     - mono: 4.2.2
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ script:
 
 matrix:
   allow_failures:
-    - mono: latest
+    - mono: 4.2.2


### PR DESCRIPTION

I'm hopeful that https://github.com/fsharp/fsharp/issues/528 has been fixed in Mono latest. It is present in Mono 4.2.2.  So let's try turning on allow-failures for Mono 4.2.2 and turning it off for Mono latest.