### PR TITLE
configure: adjust new reason for recommending higher Mono version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,13 +26,14 @@ AC_MSG_NOTICE("PKG_CONFIG_LIBDIR: $PKG_CONFIG_LIBDIR")
 
 MONO_REQUIRED_VERSION=4.0
 MONO_RECOMMENDED_VERSION=4.2
+MONO_RECOMMENDED_REASON="as it is newer and already considered a stable version"
 
 if ! $PKG_CONFIG --atleast-version=$MONO_REQUIRED_VERSION mono; then
 	AC_MSG_ERROR("You need mono $MONO_REQUIRED_VERSION")
 fi
 
 if ! $PKG_CONFIG --atleast-version=$MONO_RECOMMENDED_VERSION mono; then
-	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, for better GC performance])
+	AC_MSG_WARN([Mono $MONO_RECOMMENDED_VERSION or higher is recommended, $MONO_RECOMMENDED_REASON])
 fi
 
 # Checks for libraries.


### PR DESCRIPTION
Previous commit[1] that changed this variable didn't update the
reasoning employed in the warning message.

[1] https://github.com/fsharp/fsharp/commit/ee089bfb434c6b2d96d5fa2da4b8e53958b69dd9