### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+## How to contribute to F&#35;
+
+See [contributing guide][fsharp-contributing-guide] for more info
+
+### First, check if this is the right repository
+
+The https://github.com/fsharp/fsharp repository is for cross platform packaging only.
+The development of compiler and core library it's in the [Microsoft/visualfsharp][Microsoft/visualfsharp] repository
+
+* **Do you think it's specific of Mono or OSX/Linux?** That's the right repository
+
+* **It's about Windows or Visual Studio?** You should go to the [Microsoft/visualfsharp][Microsoft/visualfsharp] repository
+
+* **It's a general bug/feature in compiler/core library?** You should go to the [Microsoft/visualfsharp][Microsoft/visualfsharp] repository
+
+* **Not sure?** You should go to the [Microsoft/visualfsharp][Microsoft/visualfsharp] repository
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/fsharp/fsharp/issues) and in the [Microsoft/visualfsharp Issues](https://github.com/Microsoft/visualfsharp/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/fsharp/fsharp/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+
+* For more detailed information on submitting a bug report and creating an issue, visit our [contributing guide][fsharp-contributing-guide].
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### **Do you intend to add a new feature or change an existing one?**
+
+* It's about about the future evolution of the F# Language or Core Library? Suggest your change in the [F# Language Design User Voice site](https://fslang.uservoice.com/forums/245727-f-language).
+  After a feature/change is "approved-in-principle", it's discussed in the [F# language design repository](https://github.com/fsharp/FSharpLangDesign/issues)
+  and implemented as Github pull request in the [Microsoft/visualfsharp][Microsoft/visualfsharp] repository
+  
+* Otherwise, open a Github pull request
+
+#### **Do you have questions about the source code?**
+
+* Ask any question about how to use F# in the [F# mailing list](https://groups.google.com/forum/m/#!forum/fsharp-opensource) 
+
+* Check the Contribute section in the [fsharp.org site](http://fsharp.org/) for more info
+
+</br>
+
+Thanks!
+
+The [F# Core Engineering Group][fsg] (a technical working group of [The F# Software Foundation][fsf])
+
+ [fsg]: http://fsharp.github.io/
+ [fsf]: http://fsharp.org
+ [Microsoft/visualfsharp]: https://github.com/Microsoft/visualfsharp
+ [fsharp-contributing-guide]: http://fsharp.github.io/2014/06/18/fsharp-contributions.html
+ 


### PR DESCRIPTION
This repository it's often used instead of Microsoft/visualfsharp, let's make it easier to understand the difference

The `CONTRIBUTING.md` use the github [Setting guidelines for repository contributors](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) to show a link to this file when someone opens a pull request or creates an issue

Maybe a warning about the two repositories should be inside the [issue template](the https://help.github.com/articles/creating-an-issue-template-for-your-repository/)