### PR TITLE
Remove old Mono workarounds

### DIFF
--- a/src/FSharpSource.targets
+++ b/src/FSharpSource.targets
@@ -367,8 +367,6 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <DefineConstants>$(DefineConstants);PUT_TYPE_PROVIDERS_IN_FSCORE</DefineConstants>
     <DefineConstants>$(DefineConstants);QUERIES_IN_FSLIB</DefineConstants>
 
-    <!-- An explicit search path seems to be needed on Mono 3.4.0 otherwise the reference assemblies for the profile aren't found -->
-    <AssemblySearchPaths Condition="Exists('$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.0\mscorlib.dll')">$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.0</AssemblySearchPaths>
     <TargetFrameworkProfile>Profile47</TargetFrameworkProfile>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.0</TargetFrameworkVersion>
   </PropertyGroup>
@@ -410,8 +408,6 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <DefineConstants>$(DefineConstants);QUERIES_IN_FSLIB</DefineConstants>
     <TargetProfile>netcore</TargetProfile>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
-    <!-- An explicit search path seems to be needed on Mono 3.4.0 otherwise the reference assemblies for the profile aren't found -->
-    <AssemblySearchPaths Condition="Exists('$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.5\System.Runtime.dll')">$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.5</AssemblySearchPaths>
     <OtherFlags>$(OtherFlags) --targetprofile:netcore</OtherFlags>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.5</TargetFrameworkVersion>    
   </PropertyGroup>
@@ -453,8 +449,6 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <TargetProfile>netcore</TargetProfile>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
     <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v4.5</TargetFrameworkVersion>
-    <!-- An explicit search path seems to be needed on Mono 3.4.0 otherwise the reference assemblies for the profile aren't found -->
-    <AssemblySearchPaths Condition="Exists('$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.5\System.Runtime.dll')">$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.5</AssemblySearchPaths>
     <OtherFlags>$(OtherFlags) --targetprofile:netcore</OtherFlags>    
   </PropertyGroup>
 
@@ -495,8 +489,6 @@ Some other NuGET monikers to support in the future, see http://docs.nuget.org/do
     <TargetProfile>netcore</TargetProfile>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <!-- An explicit search path seems to be needed on Mono 3.4.0 otherwise the reference assemblies for the profile aren't found -->
-    <AssemblySearchPaths Condition="Exists('$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.5\System.Runtime.dll')">$(MSBuildExtensionsPath32)\..\xbuild-frameworks\.NETPortable\v4.5</AssemblySearchPaths>
     <OtherFlags>$(OtherFlags) --targetprofile:netcore</OtherFlags>    
   </PropertyGroup>
 

--- a/src/fsharp/FSharp.Build/Microsoft.Portable.FSharp.targets
+++ b/src/fsharp/FSharp.Build/Microsoft.Portable.FSharp.targets
@@ -24,59 +24,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                 Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets') AND
                            !Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.props')"/>
 
-    
-    <!-- Try to do it ourselves - Explicitly include contents of Microsoft.Portable.Core.props + Microsoft.FSharp.Targets + Microsoft.Portable.Core.targets -->
-    <!-- START MONO 3.2.7 WORKAROUND PART 1 -->
-        <PropertyGroup 
-                Condition="(!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')) AND
-                           (!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.props'))">
-		<AvailablePlatforms>Any CPU</AvailablePlatforms>
-
-		<TargetPlatformIdentifier>Portable</TargetPlatformIdentifier>
-		<TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
-		<TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
-
-		<AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
-		<NoStdLib>true</NoStdLib>
-
-		<ImplicitlyExpandTargetFramework Condition="'$(ImplicitlyExpandTargetFramework)' == '' ">true</ImplicitlyExpandTargetFramework>
-	</PropertyGroup>
-        <!-- END MONO 3.2.7 WORKAROUND PART 1 -->
-
-
 	<Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
-
-
-    <!-- START MONO 3.2.7 WORKAROUND PART 2 -->
-	<PropertyGroup 
-                Condition="(!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')) AND
-                           (!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.props'))" >
-		<ResolveReferencesDependsOn>
-			$(ResolveReferencesDependsOn);
-			ImplicitlyExpandTargetFramework;
-		</ResolveReferencesDependsOn>
-
-		<ImplicitlyExpandTargetFrameworkDependsOn>
-			$(ImplicitlyExpandTargetFrameworkDependsOn);
-			GetReferenceAssemblyPaths
-		</ImplicitlyExpandTargetFrameworkDependsOn>
-	</PropertyGroup>
-
-	<Target Name="ImplicitlyExpandTargetFramework"
-		DependsOnTargets="$(ImplicitlyExpandTargetFrameworkDependsOn)"
-                Condition="(!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.0\Microsoft.Portable.Common.targets')) AND
-                           (!Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.props'))" >
-
-		<ItemGroup>
-			<ReferenceAssemblyPaths Include="$(_TargetFrameworkDirectories)"/>
-			<ReferencePath Include="%(ReferenceAssemblyPaths.Identity)\*.dll">
-				<CopyLocal>false</CopyLocal>
-				<ResolvedFrom>ImplicitlyExpandTargetFramework</ResolvedFrom>
-				<IsSystemReference>True</IsSystemReference>
-			</ReferencePath>
-		</ItemGroup>
-	</Target>
-        <!-- END MONO 3.2.7 WORKAROUND PART 2 -->
 
 	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.targets"
                 Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\Portable\Microsoft.Portable.Core.props')"/>


### PR DESCRIPTION
Remove old Mono workarounds.

One is dead code, the other breaks on Mono 4.6+.

Note that this will probably break on Mono < 4.6.