### PR TITLE
Add missing install-sdk-lib for FSharp.Compiler.Interactive.Settings, etc.

### DIFF
--- a/src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile.in
+++ b/src/fsharp/FSharp.Compiler.Interactive.Settings/Makefile.in
@@ -8,7 +8,7 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-gac-lib install-gac-lib-net40
+install: install-gac-lib install-gac-lib-net40 install-sdk-lib
 
 
 

--- a/src/fsharp/FSharp.Compiler.Server.Shared/Makefile.in
+++ b/src/fsharp/FSharp.Compiler.Server.Shared/Makefile.in
@@ -8,7 +8,7 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-gac-lib install-gac-lib-net40
+install: install-gac-lib install-gac-lib-net40 install-sdk-lib
 
 
 

--- a/src/fsharp/FSharp.Core/Makefile.in
+++ b/src/fsharp/FSharp.Core/Makefile.in
@@ -9,6 +9,6 @@ include @abs_top_builddir@/config.make
 
 include $(topdir)/src/fsharp/targets.make
 
-install: install-gac-lib install-gac-lib-net40 
+install: install-gac-lib install-gac-lib-net40 install-sdk-lib
 
 


### PR DESCRIPTION
Per #198, `FSharp.Compiler.Interactive.Settings.dll` needs to be installed into the same directory as `fsi.exe`. (probably also `FSharp.Compiler.Server.Shared.dll` and `FSharp.Core.dll`?)

Fixes #613.