### PR TITLE
fix packaging of FSharp.Core

### DIFF
--- a/FSharp.Core.Nuget/FSharp.Core.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.nuspec
@@ -68,10 +68,16 @@
     <file src="..\lib\bootstrap\signed\.NETFramework\v2.0\2.3.0.0\FSharp.Core.xml" target="lib\net20\FSharp.Core.xml" />
 
     <!-- .NET 4.0 -->
-    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.dll" target="lib\net40\FSharp.Core.dll" />
-    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.optdata" target="lib\net40\FSharp.Core.optdata" />
-    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.sigdata" target="lib\net40\FSharp.Core.sigdata" />
-    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.xml" target="lib\net40\FSharp.Core.xml" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.0.0\FSharp.Core.dll" target="lib\net40\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.0.0\FSharp.Core.optdata" target="lib\net40\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.0.0\FSharp.Core.sigdata" target="lib\net40\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.0.0\FSharp.Core.xml" target="lib\net40\FSharp.Core.xml" />
+
+    <!-- .NET 4.5 -->
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.dll" target="lib\net45\FSharp.Core.dll" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.optdata" target="lib\net45\FSharp.Core.optdata" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.sigdata" target="lib\net45\FSharp.Core.sigdata" />
+    <file src="..\lib\bootstrap\signed\.NETFramework\v4.0\4.4.1.0\FSharp.Core.xml" target="lib\net45\FSharp.Core.xml" />
 
     <!-- .NET Portable Profile 7 -->
     <file src="..\lib\bootstrap\signed\.NETCore\3.7.41.0\FSharp.Core.dll" target="lib\portable-net45+netcore45\FSharp.Core.dll" />


### PR DESCRIPTION
FSharp.Core . 4.4.1 is not compatible with net40 and should therefore be not packaged in the net40 folder.

Two open questions:
- What about the net20 folder: Currently we package:
![image](https://cloud.githubusercontent.com/assets/1866463/23719860/346f7562-043d-11e7-9cdb-7580b13a15e7.png)
  (Note the Platform ".Net Framework v4.6.1", maybe we should just drop that one?)
- I'm still unsure if we should it move out of the `.NETFramework\v4.0` folder as well?

Otherwise this should work and fix the immediate issue in https://github.com/fsharp/fsharp/issues/672