### PR TITLE
FSharp.Compiler.Tools: set FSharpTargetsPath when using the old SDK

### DIFF
--- a/FSharp.Compiler.Tools.Nuget/FSharp.Compiler.Tools.nuspec
+++ b/FSharp.Compiler.Tools.Nuget/FSharp.Compiler.Tools.nuspec
@@ -52,6 +52,11 @@
 	<!-- Microsoft.FSharp.targets : Used in the source tree as of 08/04/2016 (prior this was Microsoft.FSharp.Targets) -->
 
     <file src="..\Release\net40\bin\Microsoft.FSharp.Targets" target="tools\Microsoft.FSharp.Targets" />
+	
+	<!-- Microsoft.Portable.FSharp.targets: used in source tree -->
+	<!-- Microsoft.Portable.FSharp.Targets: imported by project templates -->
+    <file src="..\Release\net40\bin\Microsoft.Portable.FSharp.targets" target="tools\Microsoft.Portable.FSharp.Targets" />
+	
     <file src="..\Release\net40\bin\Microsoft.Build.dll" target="tools\Microsoft.Build.dll" />
     <file src="..\Release\net40\bin\Microsoft.Build.Engine.dll" target="tools\Microsoft.Build.Engine.dll" />
     <file src="..\Release\net40\bin\Microsoft.Build.Framework.dll" target="tools\Microsoft.Build.Framework.dll" />

--- a/FSharp.Compiler.Tools.Nuget/build/FSharp.Compiler.Tools.props
+++ b/FSharp.Compiler.Tools.Nuget/build/FSharp.Compiler.Tools.props
@@ -28,8 +28,9 @@ WARNING:  You CAN MODIFY this file, doesnt matter if you are not knowledgeable a
   <!-- ref https://github.com/dotnet/standard/blob/master/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets#L12 -->
   <!-- Condition here is a hack until https://github.com/dotnet/sdk/issues/534 is fixed -->
   <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">
-    <!-- when using the old SDK, override FSharpTargetsPath -->
+    <!-- when using the old SDK, override FSharpTargetsPath and PortableFSharpTargetsPath -->
     <FSharpTargetsPath>$(MSBuildThisFileDirectory)../tools/Microsoft.FSharp.Targets</FSharpTargetsPath>
+    <PortableFSharpTargetsPath>$(MSBuildThisFileDirectory)../tools/Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
   </PropertyGroup>
   
   <Choose>

--- a/FSharp.Compiler.Tools.Nuget/build/FSharp.Compiler.Tools.props
+++ b/FSharp.Compiler.Tools.Nuget/build/FSharp.Compiler.Tools.props
@@ -24,6 +24,14 @@ WARNING:  You CAN MODIFY this file, doesnt matter if you are not knowledgeable a
 
   </PropertyGroup>
 
+
+  <!-- ref https://github.com/dotnet/standard/blob/master/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets#L12 -->
+  <!-- Condition here is a hack until https://github.com/dotnet/sdk/issues/534 is fixed -->
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">
+    <!-- when using the old SDK, override FSharpTargetsPath -->
+    <FSharpTargetsPath>$(MSBuildThisFileDirectory)../tools/Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
+  
   <Choose>
     <When Condition="'$(MSBuildRuntimeType)' == 'Core'">
       <PropertyGroup>

--- a/FSharp.Compiler.Tools.Nuget/build/FSharp.Compiler.Tools.props
+++ b/FSharp.Compiler.Tools.Nuget/build/FSharp.Compiler.Tools.props
@@ -30,7 +30,7 @@ WARNING:  You CAN MODIFY this file, doesnt matter if you are not knowledgeable a
   <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">
     <!-- when using the old SDK, override FSharpTargetsPath and PortableFSharpTargetsPath -->
     <FSharpTargetsPath>$(MSBuildThisFileDirectory)../tools/Microsoft.FSharp.Targets</FSharpTargetsPath>
-    <PortableFSharpTargetsPath>$(MSBuildThisFileDirectory)../tools/Microsoft.Portable.FSharp.Targets</FSharpTargetsPath>
+    <PortableFSharpTargetsPath>$(MSBuildThisFileDirectory)../tools/Microsoft.Portable.FSharp.Targets</PortableFSharpTargetsPath>
   </PropertyGroup>
   
   <Choose>


### PR DESCRIPTION
This is a continuation of https://github.com/fsharp/fsharp/pull/675

With the changed templates from https://github.com/Microsoft/visualfsharp/pull/2575 this should allow to override the .targets without needing to modify the fsproj. (Obviously only for new projects created with these templates).

TODO: what about portable targets? I think we would need to include ``Microsoft.Portable.FSharp.Targets`` in the nuget and set ``PortableFSharpTargetsPath``.

-------------

I have tested that the Condition evaluates to true when using the old sdk.
Will try to create a net core environment where I can test this, it looks like net core as installed with VS is broken ...

__Edit:__
The issue was that you need to run ``dotnet restore`` after ``dotnet new console -lang F#`` and before ``dotnet build``, otherwise it errors out.

I have tested that the condition evaluates to false when run from ``dotnet build``.

ref https://github.com/dotnet/standard/blob/master/Microsoft.Packaging.Tools/tasks/targets/Microsoft.Packaging.Tools.targets#L12

which was linked by eerhardt in the previous pr.

----------------

cc @enricosada , @dsyme 