### PR TITLE
Refresh compiler tools

### DIFF
--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,6 +1,6 @@
 
 # the version under development, update after a release
-$version = '4.1.0.2'
+$version = '4.1.1'
 
 function isVersionTag($tag){
     $v = New-Object Version

--- a/lib/netcore/fsc/project.json
+++ b/lib/netcore/fsc/project.json
@@ -12,7 +12,7 @@
           "type": "platform",
           "version": "1.0.1"
         },
-        "Microsoft.FSharp.Compiler.netcore": "1.0.0-rc-170122",
+        "Microsoft.FSharp.Compiler.netcore": "1.0.0-rc-170316-0"
       },
       "imports": "dnxcore50"
     }


### PR DESCRIPTION
to update `FSharp.Compiler.Tools` package with new `FSharp.Build.dll`, required to enable FSAC on new fsproj

Followup of https://github.com/Microsoft/visualfsharp/issues/2625

as a note, i used version `4.1.1`, so from now on we can use major.minor.patch (ref #682)

i am testing of integration of all packages with https://github.com/dotnet/netcorecli-fsc/pull/88 and another PR in vscode to test FSAC.

