### PR TITLE
Changes to make the build work with Mono 4.9+

### DIFF
--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -616,16 +616,18 @@ let convFieldInit x =
 // it isn't we resort to this technique...
 let TypeBuilderInstantiationT = 
     let ty = 
+        Type.GetType("System.Reflection.Emit.TypeBuilderInstantiation")
 #if ENABLE_MONO_SUPPORT
-        if runningOnMono then 
+    let ty =
+        if runningOnMono && (isNull ty) then
             Type.GetType("System.Reflection.MonoGenericClass")
         else
+            ty
 #endif
-            Type.GetType("System.Reflection.Emit.TypeBuilderInstantiation")
     assert (not (isNull ty))
     ty
 
-let typeIsNotQueryable (typ : Type) =
+let typeIsNotQueryable (typ : Type) = 
 #if FX_RESHAPED_REFLECTION
     let typ = typ.GetTypeInfo()
 #endif

--- a/src/scripts/fssrgen.fsx
+++ b/src/scripts/fssrgen.fsx
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
 let PrintErr(filename, line, msg) =
     printfn "%s(%d): error : %s" filename line msg
         
@@ -9,7 +8,7 @@ let Err(filename, line, msg) =
     printfn "# comment"
     printfn "ident,\"string\""
     printfn "errNum,ident,\"string\""
-    failwithf "there were errors in the file '%s'" filename
+    failwith (sprintf "there were errors in the file '%s'" filename)
 
 let xmlBoilerPlateString = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <root>


### PR DESCRIPTION
Looks like the problem is due to this commit to
Mono https://github.com/mono/mono/commit/efd53c8e2f1823568309a2920091b724be0feff8
Mono's internal System.Reflection.Emit.MonoGenericClass was renamed
to System.Reflection.Emit.TypeBuilderInstantiation

That broke the workaround in https://github.com/fsharp/fsharp/blob/5a942daf930d7023c78f578ec6876b86a6f13f1e/src/absil/ilreflect.fs#L619-L623 .

fixes #685 