### PR TITLE
[WIP] Allow the creation of portable pdb files on Mono

### DIFF
--- a/src/absil/ilwrite.fs
+++ b/src/absil/ilwrite.fs
@@ -4188,7 +4188,7 @@ let writeBinaryAndReportMappings (outfile, ilg: ILGlobals, pdbfile: string optio
     begin match pdbfile with
     | None -> ()
 #if ENABLE_MONO_SUPPORT
-    | Some fmdb when runningOnMono -> 
+    | Some fmdb when runningOnMono && not portablePDB ->
         writeMdbInfo fmdb outfile pdbData
 #endif
     | Some fpdb -> 

--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -144,8 +144,8 @@ let pdbGetCvDebugInfo (mvid:byte[]) (timestamp:int32) (filepath:string) (cvChunk
         Buffer.BlockCopy(path, 0, buffer, offset, size)
         buffer
     { iddCharacteristics = 0;                                                   // Reserved
-      iddMajorVersion = 0;                                                      // VersionMajor should be 0
-      iddMinorVersion = 0;                                                      // VersionMinor should be 0
+      iddMajorVersion = 0x0100;                                                 // VersionMajor should be 0x0100
+      iddMinorVersion = 0x504d;                                                 // VersionMinor should be 0x504d
       iddType = 2;                                                              // IMAGE_DEBUG_TYPE_CODEVIEW
       iddTimestamp = timestamp;
       iddData = iddCvBuffer;                                                    // Path name to the pdb file when built

--- a/src/absil/ilwritepdb.fs
+++ b/src/absil/ilwritepdb.fs
@@ -198,9 +198,9 @@ let checkSum (url:string) =
 //------------------------------------------------------------------------------
 
 // This function takes output file name and returns debug file name.
-let getDebugFileName outfile = 
+let getDebugFileName outfile portablePDB =
 #if ENABLE_MONO_SUPPORT
-  if IL.runningOnMono then 
+  if IL.runningOnMono && not portablePDB then
       outfile + ".mdb"
   else 
 #endif

--- a/src/absil/ilwritepdb.fsi
+++ b/src/absil/ilwritepdb.fsi
@@ -59,7 +59,7 @@ type PdbData =
 
 
 /// Takes the output file name and returns debug file name.
-val getDebugFileName: string -> string
+val getDebugFileName: string -> bool -> string
 
 /// 28 is the size of the IMAGE_DEBUG_DIRECTORY in ntimage.h 
 val sizeof_IMAGE_DEBUG_DIRECTORY : System.Int32

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -2332,12 +2332,12 @@ type TcConfigBuilder =
         let pdbfile = 
             if tcConfigB.debuginfo then
               Some (match tcConfigB.debugSymbolFile with 
-                    | None -> Microsoft.FSharp.Compiler.AbstractIL.ILPdbWriter.getDebugFileName outfile
+                    | None -> Microsoft.FSharp.Compiler.AbstractIL.ILPdbWriter.getDebugFileName outfile tcConfigB.portablePDB
 #if ENABLE_MONO_SUPPORT
                     | Some _ when runningOnMono ->
                         // On Mono, the name of the debug file has to be "<assemblyname>.mdb" so specifying it explicitly is an error
                         warning(Error(FSComp.SR.ilwriteMDBFileNameCannotBeChangedWarning(),rangeCmdArgs))
-                        Microsoft.FSharp.Compiler.AbstractIL.ILPdbWriter.getDebugFileName outfile
+                        Microsoft.FSharp.Compiler.AbstractIL.ILPdbWriter.getDebugFileName outfile tcConfigB.portablePDB
 #endif
                     | Some f -> f)   
             elif (tcConfigB.debugSymbolFile <> None) && (not (tcConfigB.debuginfo)) then


### PR DESCRIPTION
Allows the generation of .pdb files when `--debug:portable` is specified
on the command line. `--debug:full` continues to  generate .mdb files as
before.