### PR TITLE
Package like Microsoft.FSharp.Core.netcore

### DIFF
--- a/FSharp.Core.Nuget/FSharp.Core.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.nuspec
@@ -114,5 +114,9 @@
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="lib\netstandard1.6\FSharp.Core.optdata" />
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="lib\netstandard1.6\FSharp.Core.sigdata" />
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.xml" target="lib\netstandard1.6\FSharp.Core.xml" />
+    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="runtimes\any\native\FSharp.Core.optdata" />
+    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="runtimes\any\native\FSharp.Core.sigdata" />
+    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="content\any\netstandard1.6\FSharp.Core.optdata" />
+    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="content\any\netstandard1.6\FSharp.Core.sigdata" />
   </files>
 </package>


### PR DESCRIPTION
@enricosada can you review?

Download and inspect https://www.nuget.org/packages/Microsoft.FSharp.Core.netcore.
This change ensures that `FSharp.Core.optdata` and `FSharp.Core.sigdata` are copied to the output directory when publishing with dnc.