### PR TITLE
revert addition of content to FSharp.Core nuget

### DIFF
--- a/FSharp.Core.Nuget/FSharp.Core.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.nuspec
@@ -114,9 +114,5 @@
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="lib\netstandard1.6\FSharp.Core.optdata" />
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="lib\netstandard1.6\FSharp.Core.sigdata" />
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.xml" target="lib\netstandard1.6\FSharp.Core.xml" />
-    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="runtimes\any\native\FSharp.Core.optdata" />
-    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="runtimes\any\native\FSharp.Core.sigdata" />
-    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="content\any\netstandard1.6\FSharp.Core.optdata" />
-    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="content\any\netstandard1.6\FSharp.Core.sigdata" />
   </files>
 </package>

--- a/FSharp.Core.Nuget/FSharp.Core.nuspec
+++ b/FSharp.Core.Nuget/FSharp.Core.nuspec
@@ -114,5 +114,7 @@
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="lib\netstandard1.6\FSharp.Core.optdata" />
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="lib\netstandard1.6\FSharp.Core.sigdata" />
     <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.xml" target="lib\netstandard1.6\FSharp.Core.xml" />
+    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.optdata" target="runtimes\any\native\FSharp.Core.optdata" />
+    <file src="..\packages\Microsoft.FSharp.Core.netcore.1.0.0-rc-170122\lib\netstandard1.6\FSharp.Core.sigdata" target="runtimes\any\native\FSharp.Core.sigdata" />
   </files>
 </package>

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,6 +1,6 @@
 
 # the version under development, update after a release
-$version = '4.1.12'
+$version = '4.1.13'
 
 function isVersionTag($tag){
     $v = New-Object Version

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,6 +1,6 @@
 
 # the version under development, update after a release
-$version = '4.1.13'
+$version = '4.1.14'
 
 function isVersionTag($tag){
     $v = New-Object Version


### PR DESCRIPTION
Adding these "content" files to FSharp.Core has caused issues.  

Users of this package who want to do compilation at runtime should find other ways of making sure the relevant files are deployed along with their project, e.g. 

- by using explicit "content" or "Copy" entries for specific versions of the files, adding these entries to their project file, and directly referencing the files from the relevant "lib" directory of the project (TODO: add an example of what's needed)

- or else acquire and cache a fresh copy of the FSharp.Core nuget package when their application runs, perhaps by using a package management tool


