### PR TITLE
fix fsc binding redirect

### DIFF
--- a/src/fsharp/Fsc/fsc.exe.config
+++ b/src/fsharp/Fsc/fsc.exe.config
@@ -8,10 +8,6 @@
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="2.0.0.0-4.4.1.0" newVersion="4.4.1.0"/>
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
the 'System.Collections.Immutable' referenced by fsc is 1.2.0.0 and is also the one
contained inside the nupkg

both `FSharp.Compiler.Tools` 4.1.5 has an issue (bundle 1.2.0 but reference 1.2.1)
and latest (4.1.14) who has a binding redirect to 1.2.1 but ref and bundle 1.2.0