### PR TITLE
add System.ValueTuple.dll to nuget package and fix default reference

### DIFF
--- a/CHANGELOG-fsharp.md
+++ b/CHANGELOG-fsharp.md
@@ -1,3 +1,6 @@
+4.1.22
+  * Fix nuget package for FSharp.Compiler.Tools System.ValueTuple.dll
+
 4.1.21
   * Fix nuget package for FSharp.Compiler.Tools
 

--- a/CHANGELOG-fsharp.md
+++ b/CHANGELOG-fsharp.md
@@ -1,4 +1,4 @@
-4.1.22
+4.1.23
   * Fix nuget package for FSharp.Compiler.Tools System.ValueTuple.dll
 
 4.1.21

--- a/FSharp.Compiler.Tools.Nuget/FSharp.Compiler.Tools.nuspec
+++ b/FSharp.Compiler.Tools.Nuget/FSharp.Compiler.Tools.nuspec
@@ -44,6 +44,7 @@
     <file src="..\Release\net40\bin\FSharp.Build.xml" target="tools\FSharp.Build.xml" />
     <file src="..\Release\net40\bin\System.Collections.Immutable.dll" target="tools\System.Collections.Immutable.dll" />
     <file src="..\Release\net40\bin\System.Reflection.Metadata.dll" target="tools\System.Reflection.Metadata.dll" />
+    <file src="..\Release\net40\bin\System.ValueTuple.dll" target="tools\System.ValueTuple.dll" />
     <file src="..\Release\net40\bin\Microsoft.DiaSymReader.dll" target="tools\Microsoft.DiaSymReader.dll" />
     <file src="..\Release\net40\bin\Microsoft.DiaSymReader.PortablePdb.dll" target="tools\Microsoft.DiaSymReader.PortablePdb.dll" />
 

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1641,7 +1641,7 @@ let GetDefaultFSharpCoreReference() = typeof<list<int>>.Assembly.Location
 let GetDefaultSystemValueTupleReference() = 
     let path = Path.GetDirectoryName(GetDefaultFSharpCoreReference())
     let file = Path.Combine(path, "System.ValueTuple.dll")
-    if File.SafeExists file then Some file
+    if FileSystem.SafeExists file then Some file
     else None
 
 let GetFsiLibraryName () = "FSharp.Compiler.Interactive.Settings"  

--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -1639,12 +1639,10 @@ let GetDefaultFSharpCoreReference() = typeof<list<int>>.Assembly.Location
 
 // If necessary assume a reference to the latest System.ValueTuple with which those tools are built.
 let GetDefaultSystemValueTupleReference() = 
-    try 
-       let asm = typeof<System.ValueTuple<int,int>>.Assembly
-       if asm.FullName.StartsWith "System.ValueTuple" then 
-           Some asm.Location 
-       else None
-    with _ -> None
+    let path = Path.GetDirectoryName(GetDefaultFSharpCoreReference())
+    let file = Path.Combine(path, "System.ValueTuple.dll")
+    if File.SafeExists file then Some file
+    else None
 
 let GetFsiLibraryName () = "FSharp.Compiler.Interactive.Settings"  
 


### PR DESCRIPTION
We are getting this error from FSharp.Compiler.Tools

    [00:02:34]   EXEC : error FS0193: Could not load file or assembly 'System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified. [C:\projects\fsharp\src\fsharp\Fsc-proto\Fsc-proto.fsproj]
[00:02:34]   C:\projects\fsharp\src\scripts\fssrgen.targets(27,5): error MSB3073: The command ""C:\projects\fsharp\packages\FSharp.Compiler.Tools.4.1.21\tools\fsi.exe" --exec "C:\projects\fsharp\src\scripts\fssrgen.fsx" "C:\projects\fsharp\src\fsharp\FSComp.txt" "obj\net40\FSComp.fs"  "obj\net40\FSComp.resx" " exited with code 1. [C:\projects\fsharp\src\fsharp\Fsc-proto\Fsc-proto.fsproj]

This should fix that