### PR TITLE
cleanup flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,30 +44,18 @@ build:
 	cp -p packages/FSharp.Core.3.0.2/lib/net40/* $(Configuration)/fsharp30/net40/bin
 	cp -p packages/FSharp.Core.3.1.2.5/lib/net40/* $(Configuration)/fsharp31/net40/bin
 	cp -p packages/FSharp.Core.4.0.0.1/lib/net40/* $(Configuration)/fsharp40/net40/bin
-ifeq ("$(pclenabled47)", "yes")
 	mkdir -p $(Configuration)/portable7/bin
 	cp -p packages/FSharp.Core.4.1.17/lib/portable-net45+netcore45/* $(Configuration)/portable7/bin
-endif
-ifeq ("$(pclenabled7)", "yes")
 	mkdir -p $(Configuration)/portable47/bin
 	cp -p packages/FSharp.Core.4.1.17/lib/portable-net45+sl5+netcore45/* $(Configuration)/portable47/bin
-endif
-ifeq ("$(pclenabled78)", "yes")
 	mkdir -p $(Configuration)/portable78/bin
 	cp -p packages/FSharp.Core.4.1.17/lib/portable-net45+netcore45+wp8/* $(Configuration)/portable78/bin
-endif
-ifeq ("$(pclenabled259)", "yes")
 	mkdir -p $(Configuration)/portable259/bin
 	cp -p packages/FSharp.Core.4.1.17/lib/portable-net45+netcore45+wpa81+wp8/* $(Configuration)/portable259/bin
-endif
-ifeq ("$(monodroidenabled)", "yes")
 	mkdir -p $(Configuration)/monoandroid10+monotouch10+xamarinios10/bin
 	cp -p packages/FSharp.Core.4.1.17/lib/portable-net45+monoandroid10+monotouch10+xamarinios10/* $(Configuration)/monoandroid10+monotouch10+xamarinios10/bin
-endif
-ifeq ("$(xamarinmacenabled)", "yes")
 	mkdir -p $(Configuration)/xamarinmacmobile/bin
 	cp -p packages/FSharp.Core.4.1.17/lib/xamarinmac20/* $(Configuration)/xamarinmacmobile/bin
-endif
 
 
 
@@ -103,24 +91,12 @@ install:
 	$(MAKE) -C mono/policy.4.0.FSharp.Core TargetDotnetProfile=net40 install
 	$(MAKE) -C mono/policy.4.3.FSharp.Core TargetDotnetProfile=net40 install
 	$(MAKE) -C mono/policy.4.4.FSharp.Core TargetDotnetProfile=net40 install
-ifeq ("$(pclenabled47)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=portable47 install
-endif
-ifeq ("$(pclenabled7)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=portable7 install
-endif
-ifeq ("$(pclenabled78)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=portable78 install
-endif
-ifeq ("$(pclenabled259)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=portable259 install
-endif
-ifeq ("$(monodroidenabled)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=monoandroid10+monotouch10+xamarinios10 install
-endif
-ifeq ("$(xamarinmacenabled)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=xamarinmacmobile install
-endif
 	echo "------------------------------ INSTALLED FILES --------------"
 	ls -xlR $(DESTDIR)$(monodir)/fsharp $(DESTDIR)$(monodir)/msbuild $(DESTDIR)$(monodir)/gac/FSharp* $(DESTDIR)$(monodir)/Microsoft*
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,65 +67,6 @@ if ! test -e $MONOGACDIR45/mscorlib.dll; then
 	AC_ERROR(Couldn't find the mono gac directory or mscorlib.dll in the usual places. Set --with-gacdir=<path>)
 fi
 
-if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.0/Profile/Profile47/mscorlib.dll; then
-   PCLENABLED47=yes
-else
-   PCLENABLED47=no
-fi
-AC_MSG_NOTICE(PCL Reference Assemblies for Profile 47 found: $PCLENABLED47)
-
-AC_SUBST(PCLENABLED47)
-
-
-if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.0/Profile/Profile47/mscorlib.dll; then
-   PCLENABLED47=yes
-else
-   PCLENABLED47=no
-fi
-AC_MSG_NOTICE(PCL Reference Assemblies for Profile 47 found: $PCLENABLED47)
-
-AC_SUBST(PCLENABLED47)
-
-
-if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.5/Profile/Profile7/System.Runtime.dll; then
-   PCLENABLED7=yes
-else
-   PCLENABLED7=no
-fi
-AC_MSG_NOTICE(PCL Reference Assemblies for Profile 7 found: $PCLENABLED7)
-
-AC_SUBST(PCLENABLED7)
-
-if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.5/Profile/Profile78/System.Runtime.dll; then
-   PCLENABLED78=yes
-else
-   PCLENABLED78=no
-fi
-AC_MSG_NOTICE(PCL Reference Assemblies for Profile 78 found: $PCLENABLED78)
-
-AC_SUBST(PCLENABLED78)
-
-if test -e $MONOLIBDIR/mono/xbuild-frameworks/.NETPortable/v4.5/Profile/Profile259/System.Runtime.dll; then
-   PCLENABLED259=yes
-else
-   PCLENABLED259=no
-fi
-AC_MSG_NOTICE(PCL Reference Assemblies for Profile 259 found: $PCLENABLED259)
-
-AC_SUBST(PCLENABLED259)
-
-# We enable MonoTouch and MonoDroid builds if PCL components are available.
-# These build using binaries from dependencies/mono/2.1, but see
-# https://github.com/fsharp/fsharp/issues/391 where PCL is a requirement of
-# Microsoft.Common.targets when used in this configuration
-MONOTOUCHENABLED=$PCLENABLED78
-MONODROIDENABLED=$PCLENABLED78
-XAMARINMACENABLED=$PCLENABLED78
-
-AC_SUBST(MONOTOUCHENABLED)
-AC_SUBST(MONODROIDENABLED)
-AC_SUBST(XAMARINMACENABLED)
-
 AC_SUBST(MONOBINDIR)
 AC_SUBST(MONOLIBDIR)
 AC_SUBST(MONOGACDIR)

--- a/mono/config.make.in
+++ b/mono/config.make.in
@@ -13,14 +13,6 @@ monogacdir := @MONOGACDIR@
 
 monogacdir40 := @MONOGACDIR40@
 
-pclenabled47 := @PCLENABLED47@
-pclenabled7 := @PCLENABLED7@
-pclenabled78 := @PCLENABLED78@
-pclenabled259 := @PCLENABLED259@
-monotouchenabled := @MONOTOUCHENABLED@
-monodroidenabled := @MONODROIDENABLED@
-xamarinmacenabled := @XAMARINMACENABLED@
-
 monodir := ${libdir}mono
 
 TargetDotnetProfile = net40


### PR DESCRIPTION
These build settings are no longer needed now we are just packaging the binaries from the old nuget package