### PR TITLE
Ignore error code from ls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ ifeq ("$(xamarinmacenabled)", "yes")
 	$(MAKE) -C mono/FSharp.Core TargetDotnetProfile=xamarinmacmobile install
 endif
 	echo "------------------------------ INSTALLED FILES --------------"
-	ls -xlR $(DESTDIR)$(monodir)/fsharp $(DESTDIR)$(monodir)/msbuild $(DESTDIR)$(monodir)/gac/FSharp* $(DESTDIR)$(monodir)/Microsoft*
+	ls -xlR $(DESTDIR)$(monodir)/fsharp $(DESTDIR)$(monodir)/msbuild $(DESTDIR)$(monodir)/gac/FSharp* $(DESTDIR)$(monodir)/Microsoft* || true
 
 dist:
 	-rm -r fsharp-$(DISTVERSION) fsharp-$(DISTVERSION).tar.bz2


### PR DESCRIPTION
`ls` was returning a non-zero error code on OSX when installing due to the msbuild folder being in a different location to linux. 

As this looks as if it's for information purposes only, I changed it to ignore any error code coming from the `ls` command.