### PR TITLE
typeof in quotations.fs now respects ByRef types

### DIFF
--- a/src/fsharp/FSharp.Core/quotations.fs
+++ b/src/fsharp/FSharp.Core/quotations.fs
@@ -592,8 +592,8 @@ module Patterns =
             | WhileLoopOp,_ 
             | VarSetOp,_
             | AddressSetOp,_ -> typeof<Unit> 
-            | AddressOfOp,_ -> raise <| System.InvalidOperationException (SR.GetString(SR.QcannotTakeAddress))
-            | (QuoteOp _ | SequentialOp | TryWithOp | TryFinallyOp | IfThenElseOp | AppOp),_ -> failwith "unreachable"
+            | AddressOfOp,[expr]-> (typeOf expr).MakeByRefType()
+            | (AddressOfOp | QuoteOp _ | SequentialOp | TryWithOp | TryFinallyOp | IfThenElseOp | AppOp),_ -> failwith "unreachable"
 
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
When using ```AddressOf``` in quotations typeof function simple threw an exception which makes it impossible to call methods using byref-arguments.

Since there is a .NET-representation for byref-types why not use it?