### PR TITLE
Fix missing msbuild on Travis build (#773).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+dist: trusty
+sudo: true
 
 os:
   - linux

--- a/mono/prepare-mono.sh
+++ b/mono/prepare-mono.sh
@@ -21,7 +21,7 @@ esac
 # On Linux (or at least, Ubuntu), when building with Mono, need to install the mono-devel package first.
 if [ $OS = 'Linux' ]; then
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-    echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
+    echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
     sudo apt-get update
     sudo apt-get -y install mono-devel msbuild
 fi


### PR DESCRIPTION
New builds fail because mono packages repository is for a different distro than the Travis environment one (#773 - more on #776 comments). 

    * Move to Trusty-based Travis environment.
    * Switch to mono packages repository for Ubuntu Trusty (from Debian Wheezy).