### PR TITLE
Add NativePtr.toByref

### DIFF
--- a/src/fsharp/FSharp.Core/nativeptr.fs
+++ b/src/fsharp/FSharp.Core/nativeptr.fs
@@ -49,3 +49,6 @@ module NativePtr =
     [<CompiledName("StackAllocate")>]
     let inline stackalloc (count:int) : nativeptr<'T> = (# "localloc" (count * sizeof<'T>) : nativeptr<'T> #)
 
+    [<NoDynamicInvocation>]
+    [<CompiledName("ToByRefInlined")>]
+    let inline toByRef (x: nativeptr<'T>) : byref<'T> = (# "" x : 'T byref  #)

--- a/src/fsharp/FSharp.Core/nativeptr.fs
+++ b/src/fsharp/FSharp.Core/nativeptr.fs
@@ -51,4 +51,4 @@ module NativePtr =
 
     [<NoDynamicInvocation>]
     [<CompiledName("ToByRefInlined")>]
-    let inline toByRef (x: nativeptr<'T>) : byref<'T> = (# "" x : 'T byref  #)
+    let inline toByRef (address: nativeptr<'T>) : byref<'T> = (# "" address : 'T byref  #)

--- a/src/fsharp/FSharp.Core/nativeptr.fs
+++ b/src/fsharp/FSharp.Core/nativeptr.fs
@@ -50,5 +50,5 @@ module NativePtr =
     let inline stackalloc (count:int) : nativeptr<'T> = (# "localloc" (count * sizeof<'T>) : nativeptr<'T> #)
 
     [<NoDynamicInvocation>]
-    [<CompiledName("ToByRefInlined")>]
-    let inline toByRef (address: nativeptr<'T>) : byref<'T> = (# "" address : 'T byref  #)
+    [<CompiledName("ToByrefInlined")>]
+    let inline toByref (address: nativeptr<'T>) : byref<'T> = (# "" address : 'T byref  #)

--- a/src/fsharp/FSharp.Core/nativeptr.fsi
+++ b/src/fsharp/FSharp.Core/nativeptr.fsi
@@ -37,7 +37,7 @@ namespace Microsoft.FSharp.NativeInterop
         /// <param name="index">The index by which to offset the pointer.</param>
         /// <returns>A typed pointer.</returns>
         val inline add : address:nativeptr<'T> -> index:int -> nativeptr<'T>
-        
+
         [<Unverifiable>]
         [<NoDynamicInvocation>]
         [<CompiledName("GetPointerInlined")>]

--- a/src/fsharp/FSharp.Core/nativeptr.fsi
+++ b/src/fsharp/FSharp.Core/nativeptr.fsi
@@ -87,5 +87,5 @@ namespace Microsoft.FSharp.NativeInterop
         /// <returns>The managed pointer.</returns>
         [<Unverifiable>]
         [<NoDynamicInvocation>]
-        [<CompiledName("ToByRefInlined")>]
-        val inline toByRef : nativeptr<'T> -> byref<'T>
+        [<CompiledName("ToByrefInlined")>]
+        val inline toByref : nativeptr<'T> -> byref<'T>

--- a/src/fsharp/FSharp.Core/nativeptr.fsi
+++ b/src/fsharp/FSharp.Core/nativeptr.fsi
@@ -37,7 +37,7 @@ namespace Microsoft.FSharp.NativeInterop
         /// <param name="index">The index by which to offset the pointer.</param>
         /// <returns>A typed pointer.</returns>
         val inline add : address:nativeptr<'T> -> index:int -> nativeptr<'T>
-
+        
         [<Unverifiable>]
         [<NoDynamicInvocation>]
         [<CompiledName("GetPointerInlined")>]
@@ -81,3 +81,11 @@ namespace Microsoft.FSharp.NativeInterop
         [<NoDynamicInvocation>]
         [<CompiledName("StackAllocate")>]
         val inline stackalloc : count:int -> nativeptr<'T>
+
+        /// <summary>Converts a given typed native pointer to a managed pointer.</summary>
+        /// <param name="address">The input pointer.</param>
+        /// <returns>The managed pointer.</returns>
+        [<Unverifiable>]
+        [<NoDynamicInvocation>]
+        [<CompiledName("ToByRefInlined")>]
+        val inline toByRef : nativeptr<'T> -> byref<'T>


### PR DESCRIPTION
The `toByref` method fills a gap in the `NativePtr` module - converting typed native pointers to byref pointers.  This is necessary, e.g., to call methods such as `Thread.VolatileRead` or `Thread.VolatileWrite`.  This method was originally proposed here https://github.com/Microsoft/visualfsharp/issues/409 but wasn't incorporated into the `NativePtr` module.