### PR TITLE
integration from visualfsharp master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,5 @@ tests/fsharpqa/testenv/bin/System.ValueTuple.dll
 /tests/fcs/
 /fcs/.paket/Paket.Restore.targets
 msbuild.binlog
+/fcs/FSharp.Compiler.Service.netstandard/*.fs
+/fcs/FSharp.Compiler.Service.netstandard/*.fsi

--- a/src/fsharp/FSComp.txt
+++ b/src/fsharp/FSComp.txt
@@ -161,7 +161,6 @@ FieldNotContainedMutablesDiffer,"The module contains the field\n    %s    \nbut 
 FieldNotContainedLiteralsDiffer,"The module contains the field\n    %s    \nbut its signature specifies\n    %s    \nThe 'literal' modifiers differ"
 FieldNotContainedTypesDiffer,"The module contains the field\n    %s    \nbut its signature specifies\n    %s    \nThe types differ"
 331,typrelCannotResolveImplicitGenericInstantiation,"The implicit instantiation of a generic construct at or near this point could not be resolved because it could resolve to multiple unrelated types, e.g. '%s' and '%s'. Consider using type annotations to resolve the ambiguity"
-332,typrelCannotResolveAmbiguityInOverloadedOperator,"Could not resolve the ambiguity inherent in the use of the operator '%s' at or near this program point. Consider using type annotations to resolve the ambiguity."
 333,typrelCannotResolveAmbiguityInPrintf,"Could not resolve the ambiguity inherent in the use of a 'printf'-style format string"
 334,typrelCannotResolveAmbiguityInEnum,"Could not resolve the ambiguity in the use of a generic construct with an 'enum' constraint at or near this position"
 335,typrelCannotResolveAmbiguityInDelegate,"Could not resolve the ambiguity in the use of a generic construct with a 'delegate' constraint at or near this position"

--- a/src/fsharp/IlxGen.fs
+++ b/src/fsharp/IlxGen.fs
@@ -3747,8 +3747,8 @@ and GenClosureTypeDefs cenv (tref:ILTypeRef, ilGenParams, attrs, ilCloFreeVars, 
       Properties = emptyILProperties
       Methods= mkILMethods mdefs 
       MethodImpls= mkILMethodImpls mimpls 
-      IsSerializable= cenv.g.attrib_SerializableAttribute.IsSome
-      IsComInterop= false    
+      IsSerializable=true
+      IsComInterop= false
       IsSpecialName= true
       NestedTypes=emptyILTypeDefs
       Encoding= ILDefaultPInvokeEncoding.Auto
@@ -3803,8 +3803,8 @@ and GenLambdaClosure cenv (cgbuf:CodeGenBuffer) eenv isLocalTypeFunc selfv expr 
                       Properties = emptyILProperties
                       Methods= mkILMethods ilContractMeths 
                       MethodImpls= emptyILMethodImpls 
-                      IsSerializable= cenv.g.attrib_SerializableAttribute.IsSome 
-                      IsComInterop=false    
+                      IsSerializable=true
+                      IsComInterop=false
                       IsSpecialName= true
                       NestedTypes=emptyILTypeDefs
                       Encoding= ILDefaultPInvokeEncoding.Auto
@@ -6563,9 +6563,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon:Tycon) =
         let ilFields = mkILFields ilFieldDefs
         
         let tdef, tdefDiscards = 
-           let isSerializable = (TryFindFSharpBoolAttribute cenv.g cenv.g.attrib_AutoSerializableAttribute tycon.Attribs <> Some(false)) 
-                             && cenv.g.attrib_SerializableAttribute.IsSome
-                                       
+           let isSerializable = (TryFindFSharpBoolAttribute cenv.g cenv.g.attrib_AutoSerializableAttribute tycon.Attribs <> Some(false))
+
            match tycon.TypeReprInfo with 
            | TILObjectRepr _ ->
                let td = tycon.ILTyconRawMetadata
@@ -6817,11 +6816,10 @@ and GenExnDef cenv mgbuf eenv m (exnc:Tycon) =
             else
                 []
 
-        
         let serializationRelatedMembers =
-            // do not emit serialization related members if target framework lacks SerializableAttribute or SerializationInfo
-          match cenv.g.attrib_SerializableAttribute, cenv.g.iltyp_SerializationInfo, cenv.g.iltyp_StreamingContext with 
-          | Some _,  Some serializationInfoType, Some streamingContextType -> 
+          // do not emit serialization related members if target framework lacks SerializationInfo or StreamingContext
+          match cenv.g.iltyp_SerializationInfo, cenv.g.iltyp_StreamingContext with 
+          | Some serializationInfoType, Some streamingContextType -> 
             let ilCtorDefForSerialziation = 
                 mkILCtor(ILMemberAccess.Family,
                         [mkILParamNamed("info", serializationInfoType);mkILParamNamed("context",streamingContextType)],
@@ -6880,7 +6878,7 @@ and GenExnDef cenv mgbuf eenv m (exnc:Tycon) =
              emptyILEvents,
              mkILCustomAttrs [mkCompilationMappingAttr cenv.g (int SourceConstructFlags.Exception)],
              ILTypeInit.BeforeField)
-        let tdef = { tdef with IsSerializable = cenv.g.attrib_SerializableAttribute.IsSome }
+        let tdef = { tdef with IsSerializable = true }
         mgbuf.AddTypeDef(tref, tdef, false, false, None)
 
 

--- a/src/fsharp/TcGlobals.fs
+++ b/src/fsharp/TcGlobals.fs
@@ -1005,7 +1005,6 @@ type public TcGlobals(compilingFslib: bool, ilg:ILGlobals, fslibCcu: CcuThunk, d
   member val attrib_ProjectionParameterAttribute           = mk_MFCore_attrib "ProjectionParameterAttribute"
   member val attrib_CustomOperationAttribute               = mk_MFCore_attrib "CustomOperationAttribute"
   member val attrib_NonSerializedAttribute                 = tryFindSysAttrib "System.NonSerializedAttribute"
-  member val attrib_SerializableAttribute                 = tryFindSysAttrib "System.SerializableAttribute"
   
   member val attrib_AutoSerializableAttribute              = mk_MFCore_attrib "AutoSerializableAttribute"
   member val attrib_RequireQualifiedAccessAttribute        = mk_MFCore_attrib "RequireQualifiedAccessAttribute"

--- a/src/fsharp/TypeRelations.fs
+++ b/src/fsharp/TypeRelations.fs
@@ -141,8 +141,7 @@ let ChooseTyparSolutionAndRange (g: TcGlobals) amap (tp:Typar) =
              match tpc with 
              | TyparConstraint.CoercesTo(x,m) -> 
                  join m x,m
-             | TyparConstraint.MayResolveMember(TTrait(_,nm,_,_,_,_),m) -> 
-                 errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInOverloadedOperator(DemangleOperatorName nm),m))
+             | TyparConstraint.MayResolveMember(TTrait(_,_,_,_,_,_),m) ->
                  maxSoFar,m
              | TyparConstraint.SimpleChoice(_,m) -> 
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInPrintf(),m))

--- a/src/fsharp/fsc.fs
+++ b/src/fsharp/fsc.fs
@@ -1968,12 +1968,10 @@ let main2b (tcImportsCapture,dynamicAssemblyCreator) (Args (ctok, tcConfig: TcCo
     use unwindBuildPhase = PushThreadBuildPhaseUntilUnwind BuildPhase.IlxGen
     let ilxGenerator = CreateIlxAssemblyGenerator (tcConfig, tcImports, tcGlobals, (LightweightTcValForUsingInBuildMethodCall tcGlobals), generatedCcu)
 
-    // Check if System.SerializableAttribute exists in mscorlib.dll, 
-    // so that make sure the compiler only emits "serializable" bit into IL metadata when it is available.
-    // Note that SerializableAttribute may be relocated in the future but now resides in mscorlib.
     let codegenResults = GenerateIlxCode ((if Option.isSome dynamicAssemblyCreator then IlReflectBackend else IlWriteBackend), Option.isSome dynamicAssemblyCreator, false, tcConfig, topAttrs, optimizedImpls, generatedCcu.AssemblyName, ilxGenerator)
     let casApplied = new Dictionary<Stamp, bool>()
     let securityAttrs, topAssemblyAttrs = topAttrs.assemblyAttrs |> List.partition (fun a -> TypeChecker.IsSecurityAttribute tcGlobals (tcImports.GetImportMap()) casApplied a rangeStartup)
+
     // remove any security attributes from the top-level assembly attribute list
     let topAttrs = {topAttrs with assemblyAttrs=topAssemblyAttrs}
     let permissionSets = ilxGenerator.CreatePermissionSets securityAttrs

--- a/src/fsharp/service/ServiceUntypedParse.fs
+++ b/src/fsharp/service/ServiceUntypedParse.fs
@@ -41,8 +41,8 @@ module SourceFileImpl =
         0 = String.Compare(".fsi",ext,StringComparison.OrdinalIgnoreCase)
 
     /// Additional #defines that should be in place when editing a file in a file editor such as VS.
-    let AdditionalDefinesForUseInEditor(filename) =
-        if CompileOps.IsScript(filename) then ["INTERACTIVE";"EDITING"] // This is still used by the foreground parse
+    let AdditionalDefinesForUseInEditor(isInteractive: bool) =
+        if isInteractive then ["INTERACTIVE";"EDITING"] // This is still used by the foreground parse
         else ["COMPILED";"EDITING"]
            
 type CompletionPath = string list * string option // plid * residue

--- a/src/fsharp/service/ServiceUntypedParse.fsi
+++ b/src/fsharp/service/ServiceUntypedParse.fsi
@@ -112,5 +112,5 @@ module public UntypedParseImpl =
 // implementation details used by other code in the compiler    
 module internal SourceFileImpl =
     val IsInterfaceFile : string -> bool 
-    val AdditionalDefinesForUseInEditor : string -> string list
+    val AdditionalDefinesForUseInEditor: isInteractive: bool -> string list
 

--- a/src/fsharp/service/service.fsi
+++ b/src/fsharp/service/service.fsi
@@ -295,6 +295,7 @@ type public FSharpParsingOptions =
       SourceFiles: string[]
       ConditionalCompilationDefines: string list
       ErrorSeverityOptions: FSharpErrorSeverityOptions
+      IsInteractive: bool
       LightSyntax: bool option
       CompilingFsLib: bool
       IsExe: bool
@@ -533,14 +534,14 @@ type public FSharpChecker =
     ///
     /// <param name="sourceFiles">Initial source files list. Additional files may be added during argv evaluation.</param>
     /// <param name="argv">The command line arguments for the project build.</param>
-    member GetParsingOptionsFromCommandLineArgs: sourceFiles: string list * argv: string list -> FSharpParsingOptions * FSharpErrorInfo list
+    member GetParsingOptionsFromCommandLineArgs: sourceFiles: string list * argv: string list * ?isInteractive: bool -> FSharpParsingOptions * FSharpErrorInfo list
 
     /// <summary>
     /// <para>Get the FSharpParsingOptions implied by a set of command line arguments.</para>
     /// </summary>
     ///
     /// <param name="argv">The command line arguments for the project build.</param>
-    member GetParsingOptionsFromCommandLineArgs: argv: string list -> FSharpParsingOptions * FSharpErrorInfo list
+    member GetParsingOptionsFromCommandLineArgs: argv: string list * ?isInteractive: bool -> FSharpParsingOptions * FSharpErrorInfo list
 
     /// <summary>
     /// <para>Get the FSharpParsingOptions implied by a FSharpProjectOptions.</para>
@@ -727,11 +728,11 @@ type public CompilerEnvironment =
 module public CompilerEnvironment =
     /// These are the names of assemblies that should be referenced for .fs or .fsi files that
     /// are not associated with a project.
-    val DefaultReferencesForOrphanSources : assumeDotNetFramework: bool -> string list
+    val DefaultReferencesForOrphanSources: assumeDotNetFramework: bool -> string list
     /// Return the compilation defines that should be used when editing the given file.
-    val GetCompilationDefinesForEditing : filename : string * parsingOptions : FSharpParsingOptions -> string list
+    val GetCompilationDefinesForEditing: parsingOptions: FSharpParsingOptions -> string list
     /// Return true if this is a subcategory of error or warning message that the language service can emit
-    val IsCheckerSupportedSubcategory : string -> bool
+    val IsCheckerSupportedSubcategory: string -> bool
 
 /// Information about the debugging environment
 module public DebuggerEnvironment =

--- a/src/fsharp/xlf/FSComp.txt.cs.xlf
+++ b/src/fsharp/xlf/FSComp.txt.cs.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Nepovedlo se přeložit implicitní vytvoření instance obecného konstruktoru na této pozici nebo blízko ní, protože by se dala přeložit na víc nesouvisejících typů, třeba {0} a {1}. Tuto nejednoznačnost můžete vyřešit pomocí poznámek typu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Nepovedlo se vyřešit nejednoznačnost vyplývající z použití operátoru {0} na tomto místě v programu nebo blízko něho. Tuto nejednoznačnost můžete vyřešit pomocí poznámek typu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Nepovedlo se vyřešit nejednoznačnost vyplývající z použití formátovacího řetězce ve stylu printf.</target>

--- a/src/fsharp/xlf/FSComp.txt.de.xlf
+++ b/src/fsharp/xlf/FSComp.txt.de.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Die implizite Instanziierung eines generischen Konstrukts an diesem Punkt oder in dessen Umgebung konnte nicht aufgelöst werden, weil sie zu mehreren unzusammenhängenden Typen aufgelöst werden könnte, z.B. "{0}" und "{1}". Verwenden Sie Typanmerkungen, um die Mehrdeutigkeit aufzulösen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Die inhärente Mehrdeutigkeit bei der Verwendung des {0}-Operators an diesem Programmpunkt oder in dessen Umgebung konnte nicht aufgelöst werden. Verwenden Sie Typanmerkungen, um die Mehrdeutigkeit aufzulösen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Die inhärente Mehrdeutigkeit bei der Verwendung einer printf-Formatzeichenfolge konnte nicht aufgelöst werden.</target>

--- a/src/fsharp/xlf/FSComp.txt.en.xlf
+++ b/src/fsharp/xlf/FSComp.txt.en.xlf
@@ -802,11 +802,6 @@
         <target state="new">The implicit instantiation of a generic construct at or near this point could not be resolved because it could resolve to multiple unrelated types, e.g. '{0}' and '{1}'. Consider using type annotations to resolve the ambiguity</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="new">Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="new">Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</target>

--- a/src/fsharp/xlf/FSComp.txt.es.xlf
+++ b/src/fsharp/xlf/FSComp.txt.es.xlf
@@ -802,11 +802,6 @@
         <target state="translated">No se pudo resolver la creación de instancia implícita de una construcción genérica en este punto o cerca de él porque se podía resolver en varios tipos no relacionados; por ejemplo, '{0}' y '{1}'. Considere el uso de anotaciones de tipo para resolver la ambigüedad.</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">No se pudo resolver la ambigüedad inherente en el uso del operador '{0}' en este punto del programa o cerca de él. Considere el uso de anotaciones de tipo para resolver la ambigüedad.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">No se pudo resolver la ambigüedad inherente en el uso de una cadena de formato de tipo 'printf'.</target>

--- a/src/fsharp/xlf/FSComp.txt.fr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.fr.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Impossible de résoudre l'instanciation implicite d'une construction générique à cet emplacement ou à proximité, car elle peut être résolue en plusieurs types non liés, par exemple '{0}' et '{1}'. Utilisez des annotations de type pour résoudre l'ambigüité</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Impossible de résoudre l'ambigüité inhérente à l'utilisation de l'opérateur '{0}' à cet emplacement du programme ou à proximité. Utilisez des annotations de type pour résoudre l'ambigüité.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Impossible de résoudre l'ambigüité inhérente à l'utilisation d'une chaîne de format de style 'printf'</target>

--- a/src/fsharp/xlf/FSComp.txt.it.xlf
+++ b/src/fsharp/xlf/FSComp.txt.it.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Non è stato possibile risolvere la creazione di istanza implicita di un costrutto generico in questo punto o in prossimità di esso perché la risoluzione potrebbe restituire più tipi non correlati, ad esempio '{0}' e '{1}'. Provare a usare annotazioni di tipo per risolvere l'ambiguità</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Non è stato possibile risolvere l'ambiguità relativa all'uso dell'operatore '{0}' in questo punto del programma o in prossimità di esso. Provare invece a risolvere l'ambiguità usando annotazioni di tipo.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Non è stato possibile risolvere l'ambiguità relativa all'uso della stringa di formato di stile 'printf'</target>

--- a/src/fsharp/xlf/FSComp.txt.ja.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ja.xlf
@@ -802,11 +802,6 @@
         <target state="translated">この場所またはその付近にあるジェネリック コンストラクトの暗黙的なインスタンス化を解決できませんでした。これは、関連性のない複数の型に解決される可能性があるためです (たとえば、'{0}' と '{1}')。あいまいさを解決するために、型の注釈を使用してください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">このプログラム ポイント、またはその付近にある演算子 '{0}' の使用に関して、あいまいな継承を解決できませんでした。あいまいさを解決するために、型の注釈を使用してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">'printf' 形式の書式指定文字列の使用に関して、あいまいな継承を解決できませんでした</target>

--- a/src/fsharp/xlf/FSComp.txt.ko.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ko.xlf
@@ -802,11 +802,6 @@
         <target state="translated">관련되지 않은 여러 형식(예: '{0}'과(와) '{1}')으로 확인될 수 있으므로 이 지점 또는 이 지점 근처에서 제네릭 구문의 암시적 인스턴스를 확인할 수 없습니다. 형식 주석을 사용하여 모호성을 해결하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">’{0}' 연산자 사용과 관련하여 이 프로그램 지점 또는 이 지점 근처에서 본질적으로 발생하는 모호성을 해결할 수 없습니다. 형식 주석을 사용하여 모호성을 해결하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">'printf' 스타일의 서식 문자열 사용과 관련하여 본질적으로 발생하는 모호성을 해결할 수 없습니다.</target>

--- a/src/fsharp/xlf/FSComp.txt.pl.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pl.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Nie można rozpoznać niejawnego wystąpienia konstrukcji ogólnej w tym miejscu lub w jego pobliżu, ponieważ może to spowodować powstanie wielu niepowiązanych typów, na przykład „{0}” i „{1}”. Rozważ użycie adnotacji typu w celu rozwiązania niejednoznaczności</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Nie można rozwiązać odziedziczonej niejednoznaczności w przypadku użycia operatora „{0}” w tym punkcie programu lub w jego pobliżu. Rozważ użycie adnotacji typu w celu rozwiązania niejednoznaczności.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Nie można usunąć niejednoznaczności spowodowanej użyciem ciągu formatu „printf”</target>

--- a/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/fsharp/xlf/FSComp.txt.pt-BR.xlf
@@ -802,11 +802,6 @@
         <target state="translated">A instanciação implícita do constructo genérico neste ponto ou próximo a ele não pode ser resolvida porque ele conseguiu resolver tipos não relacionados múltiplos, por exemplo '{0}' e '{1}'. Considere usar anotações de tipo para resolver a ambiguidade</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Não foi possível resolver a ambiguidade no uso de um operador '{0}' neste ponto do programa ou próximo a ele. Considere usar anotações de tipo para resolver a ambiguidade.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Não foi possível resolver a ambiguidade inerente ao uso de uma cadeia de caracteres com formato de estilo 'printf'</target>

--- a/src/fsharp/xlf/FSComp.txt.ru.xlf
+++ b/src/fsharp/xlf/FSComp.txt.ru.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Неявное создание экземпляров базовой конструкции в данной точке или рядом с ней не может быть разрешено, так как тогда возможно разрешение в несколько несвязанных типов, напр. "{0}" и "{1}". Рекомендуется использовать аннотации типа для решения неоднозначности</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">Не удалось разрешить неоднозначность, унаследованную в использовании оператора "{0}" в данной точке программы или рядом с ней. Рекомендуется использовать аннотации типа для решения неоднозначности.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">Не удалось разрешить неоднозначность, унаследованную в использовании строки формата вида "printf"</target>

--- a/src/fsharp/xlf/FSComp.txt.tr.xlf
+++ b/src/fsharp/xlf/FSComp.txt.tr.xlf
@@ -802,11 +802,6 @@
         <target state="translated">Genel yapının bu konumda veya yakınında örtük olarak örneklenmesi çözümlenemedi, çünkü ilişkisiz birden çok türe çözümlenebiliyordu, örn. '{0}' ve '{1}'. Belirsizliği çözümlemek için tür ek açıklamaları kullanmayı düşünün</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">'{0}' işlecinin bu program noktasında veya yakınında kullanılmasında bulunan belirsizlik çözümlenemedi. Bu belirsizliği çözmek için tür ek açıklamaları kullanmayı düşünün.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">'printf' stilindeki biçim dizesinin kullanılmasına bulunan belirsizlik çözümlenemedi.</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hans.xlf
@@ -802,11 +802,6 @@
         <target state="translated">未能解析在此点或其附近进行的泛型构造的隐式实例化，因为它可以解析为多个不相关的类型，例如“{0}”和“{1}”。请考虑使用类型批注来解析此多义性</target>
         <note />
       </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">未能解析在此程序点或其附近使用运算符“{0}”所产生的固有多义性。请考虑使用类型批注来解析此多义性。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
         <source>Could not resolve the ambiguity inherent in the use of a 'printf'-style format string</source>
         <target state="translated">未能解析使用“printf”样式的格式字符串所产生的固有多义性</target>

--- a/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/fsharp/xlf/FSComp.txt.zh-Hant.xlf
@@ -209,7 +209,7 @@
       </trans-unit>
       <trans-unit id="buildInvalidPrivacy">
         <source>Unrecognized privacy setting '{0}' for managed resource, valid options are 'public' and 'private'</source>
-        <target state="translated">Managed 資源的無法辨識隱私設定 '{0}'，有效的選項是 'public' 和 'private'</target>
+        <target state="translated">受控資源的無法辨識隱私設定 '{0}'，有效的選項是 'public' 和 'private'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildMultipleReferencesNotAllowed">
@@ -800,11 +800,6 @@
       <trans-unit id="typrelCannotResolveImplicitGenericInstantiation">
         <source>The implicit instantiation of a generic construct at or near this point could not be resolved because it could resolve to multiple unrelated types, e.g. '{0}' and '{1}'. Consider using type annotations to resolve the ambiguity</source>
         <target state="translated">無法解決在這個點或附近的泛型建構的隱含具現化，因為它可能解析成多個不相關的類型，例如 '{0}' 和 '{1}'。請考慮使用類型註釋來解決模稜兩可</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="typrelCannotResolveAmbiguityInOverloadedOperator">
-        <source>Could not resolve the ambiguity inherent in the use of the operator '{0}' at or near this program point. Consider using type annotations to resolve the ambiguity.</source>
-        <target state="translated">無法解決在這個程式點或附近使用運算子 '{0}' 時固有的模稜兩可。請考慮使用型別註解來解決模稜兩可。</target>
         <note />
       </trans-unit>
       <trans-unit id="typrelCannotResolveAmbiguityInPrintf">
@@ -1609,7 +1604,7 @@
       </trans-unit>
       <trans-unit id="csGenericConstructRequiresUnmanagedType">
         <source>A generic construct requires that the type '{0}' is an unmanaged type</source>
-        <target state="translated">泛型建構要求類型 '{0}' 必須是 Unmanaged 類型</target>
+        <target state="translated">泛型建構要求類型 '{0}' 必須是非受控類型</target>
         <note />
       </trans-unit>
       <trans-unit id="csTypeNotCompatibleBecauseOfPrintf">
@@ -4209,7 +4204,7 @@
       </trans-unit>
       <trans-unit id="optsResource">
         <source>Embed the specified managed resource</source>
-        <target state="translated">嵌入指定的 Managed 資源</target>
+        <target state="translated">嵌入指定的受控資源</target>
         <note />
       </trans-unit>
       <trans-unit id="optsLinkresource">
@@ -5469,12 +5464,12 @@
       </trans-unit>
       <trans-unit id="fscStaticLinkingNoMixedDLL">
         <source>Static linking may not include a mixed managed/unmanaged DLL</source>
-        <target state="translated">靜態連結不可包含混合的 Managed/Unmanaged DLL</target>
+        <target state="translated">靜態連結不可包含混合的受控/非受控 DLL</target>
         <note />
       </trans-unit>
       <trans-unit id="fscIgnoringMixedWhenLinking">
         <source>Ignoring mixed managed/unmanaged assembly '{0}' during static linking</source>
-        <target state="translated">在靜態連結期間忽略混合的 Managed/Unmanaged 組件 '{0}'</target>
+        <target state="translated">在靜態連結期間忽略混合的受控/非受控組件 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="fscAssumeStaticLinkContainsNoDependencies">

--- a/tests/projects/Sample_NETCoreSDK_FSharp_Library_netstandard2_0/Library1.fs
+++ b/tests/projects/Sample_NETCoreSDK_FSharp_Library_netstandard2_0/Library1.fs
@@ -1,0 +1,4 @@
+﻿namespace Sample_NETCoreSDK_FSharp_Library_netstandard2_0
+
+type Class1() = 
+    member this.X = "F#"

--- a/tests/projects/Sample_NETCoreSDK_FSharp_Library_netstandard2_0/Sample_NETCoreSDK_FSharp_Library_netstandard2_0.fsproj
+++ b/tests/projects/Sample_NETCoreSDK_FSharp_Library_netstandard2_0/Sample_NETCoreSDK_FSharp_Library_netstandard2_0.fsproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
-    <!-- <DebugType>portable</DebugType> -->
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library1.fs" />


### PR DESCRIPTION
@dsyme I appreciate the direction getting started with this.  I went through the steps pulling in two additional commits compared to #808, however 30 _fewer_ files were changed.  The difference seems to be the files being removed under src/fsharp/xlf.  Should I remove those as well?

One additional note, build succeeds but tests fail with the following - any suggestions or might this be my environment (Docker `mono:latest` image):
```
Running libtest....OK
Running int32....OK
Running attributes....OK
FAILURE: math/measures/test.fsx - System.InvalidProgramException: Invalid IL code in Core_genericMeasures:foo (): IL_0005: stloc.0   


  at Core_genericMeasures.RunAll () [0x00000] in <5a61567b229e38e0a74503837b56615a>:0 
  at Core_genericMeasures.RUN[a] () [0x00000] in <5a61567b229e38e0a74503837b56615a>:0 
  at Run-all+clo@108-1349.Invoke (Microsoft.FSharp.Core.Unit arg00@) [0x00002] in <5a61567b229e38e0a74503837b56615a>:0 
  at Run-all.check (System.String dir, Microsoft.FSharp.Core.FSharpFunc`2[T,TResult] f) [0x0000c] in <5a61567b229e38e0a74503837b56615a>:0 
```