### PR TITLE
Fix build on latest mono

### DIFF
--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -36,7 +36,7 @@ module Scripting =
 #if INTERACTIVE
     let argv = Microsoft.FSharp.Compiler.Interactive.Settings.fsi.CommandLineArgs |> Seq.skip 1 |> Seq.toArray
 
-    let getCmdLineArgOptional switchName = 
+    let getCmdLineArgOptional (switchName: string) =
         argv |> Array.filter(fun t -> t.StartsWith(switchName)) |> Array.map(fun t -> t.Remove(0, switchName.Length).Trim()) |> Array.tryHead 
 
     let getCmdLineArg switchName defaultValue = 


### PR DESCRIPTION
We need to be explicit about the type of switchName as
String.StartsWith recently got a new char overload during the
last corefx import.

Fixes https://github.com/mono/mono/issues/7805