### PR TITLE
fix build failure on Mono latest

### DIFF
--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -64,7 +64,7 @@ module Scripting =
     let getFilename (path: string) = Path.GetFileName path
     let getDirectoryName (path: string) = Path.GetDirectoryName path
 
-    let copyFile source dir =
+    let copyFile (source: string) dir =
         let dest = 
             if not (Directory.Exists dir) then Directory.CreateDirectory dir |>ignore
             let result = Path.Combine(dir, Path.GetFileName source)

--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -59,10 +59,10 @@ module Scripting =
 
     let (++) a b = Path.Combine(a,b)
 
-    let getBasename a = Path.GetFileNameWithoutExtension a
-    let getFullPath a = Path.GetFullPath a
-    let getFilename a = Path.GetFileName a
-    let getDirectoryName a = Path.GetDirectoryName a
+    let getBasename (path: string) = Path.GetFileNameWithoutExtension path
+    let getFullPath (path: string) = Path.GetFullPath path
+    let getFilename (path: string) = Path.GetFileName path
+    let getDirectoryName (path: string) = Path.GetDirectoryName path
 
     let copyFile source dir =
         let dest = 


### PR DESCRIPTION

The CoreFX addition of new overloads to very basic methods such as `GetFileName` has busted some F# code.

Trying to patch up the build here