### PR TITLE
Downgrade build script for MSBuild 12.0.

### DIFF
--- a/build/targets/CommonPackages.targets
+++ b/build/targets/CommonPackages.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
     <PackageReference Include="XliffTasks" Version="$(XliffTasksPackageVersion)" />

--- a/build/targets/ConvertPortablePdbs.targets
+++ b/build/targets/ConvertPortablePdbs.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbPackageVersion)" />

--- a/build/targets/GenerateAssemblyAttributes.targets
+++ b/build/targets/GenerateAssemblyAttributes.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="GitHash.props" />
 

--- a/build/targets/GenerateInternalsVisibleTo.targets
+++ b/build/targets/GenerateInternalsVisibleTo.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <GeneratedFSharpInternalsVisibleToFile>$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedFSharpInternalsVisibleToFile>

--- a/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
+++ b/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj
@@ -39,19 +39,24 @@
     <Compile Include="..\FSharp.Build\WriteCodeFragment.fs">
       <Link>WriteCodeFragment.fs</Link>
     </Compile>
-    <None Include="..\FSharp.Build\Microsoft.FSharp.Targets" CopyToOutputDirectory="PreserveNewest">
+    <None Include="..\FSharp.Build\Microsoft.FSharp.Targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.FSharp.Targets</Link>
     </None>
-    <None Include="..\FSharp.Build\Microsoft.Portable.FSharp.Targets" CopyToOutputDirectory="PreserveNewest">
+    <None Include="..\FSharp.Build\Microsoft.Portable.FSharp.Targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.Portable.FSharp.Targets</Link>
     </None>
-    <None Include="..\FSharp.Build\Microsoft.FSharp.NetSdk.props" CopyToOutputDirectory="PreserveNewest">
+    <None Include="..\FSharp.Build\Microsoft.FSharp.NetSdk.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.FSharp.NetSdk.props</Link>
     </None>
-    <None Include="..\FSharp.Build\Microsoft.FSharp.NetSdk.targets" CopyToOutputDirectory="PreserveNewest">
+    <None Include="..\FSharp.Build\Microsoft.FSharp.NetSdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.FSharp.NetSdk.targets</Link>
     </None>
-    <None Include="..\FSharp.Build\Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest">
+    <None Include="..\FSharp.Build\Microsoft.FSharp.Overrides.NetSdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>Microsoft.FSharp.Overrides.NetSdk.targets</Link>
     </None>
   </ItemGroup>

--- a/src/fsharp/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/FSharp.Build/FSharp.Build.fsproj
@@ -33,11 +33,21 @@
     <Compile Include="FSharpEmbedResXSource.fs" />
     <Compile Include="WriteCodeFragment.fs" />
     <Compile Include="CreateFSharpManifestResourceName.fs" />
-    <None Include="Microsoft.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="Microsoft.Portable.FSharp.Targets" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="Microsoft.FSharp.NetSdk.props" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="Microsoft.FSharp.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Microsoft.FSharp.Targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Microsoft.Portable.FSharp.Targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Microsoft.FSharp.NetSdk.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Microsoft.FSharp.NetSdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Microsoft.FSharp.Overrides.NetSdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetDotnetProfile)' != 'coreclr'">


### PR DESCRIPTION
Major caveat: I don't actually know what I am doing.

Instead of creating my comment as an issue I have made it a pull request.

When I try to run the build (build.bat) with MSBuild 12.0 the build tools complain that there are missing xmlns attributes on the .target Project tags, and that they do not understand the new(?) inlined CopyToOutputDirectory attributes for the None tags in the .fsproj files.

Can this be fixed, or will it just ruin other scenarios instead?
