### PR TITLE
Added description to "convMethodRef: could not bind to method"

### DIFF
--- a/src/absil/ilreflect.fs
+++ b/src/absil/ilreflect.fs
@@ -763,7 +763,9 @@ let queryableTypeGetMethodBySearch cenv emEnv parentT (mref:ILMethodRef) =
             res
        
         match List.tryFind select methInfos with
-        | None          -> failwith "convMethodRef: could not bind to method"
+        | None -> 
+            let methNames = methInfos |> List.map (fun m -> m.Name) |> List.distinct
+            failwithf "convMethodRef: could not bind to method '%A' of type '%O'" (System.String.Join(", ", methNames)) parentT
         | Some methInfo -> methInfo (* return MethodInfo for (generic) type's (generic) method *)
           
 let queryableTypeGetMethod cenv emEnv parentT (mref:ILMethodRef) =


### PR DESCRIPTION
Recently my team experienced problems caused by `convMethodRef: could not bind to method` error when executing our scripts in FSI. However the issue with this error is that it isn't distinctively showing, what has gone wrong (I think usually it's the issue with referenced .dll files).

For us, the only way to actually see what was happening, was to enrich that error message using custom FSI build. Since I think, it'd be helpful for the rest of the community in the future - here's the PR. It includes method name and containing type info along with the actual error message. Example:

```
error FS0192: internal error: convMethodRef: could not bind to method 'QuerySelectorAll' of type 'System.HapCssExtensionMethods'
```