### PR TITLE
Help Path.IsPathRooted method overload selection.

### DIFF
--- a/src/scripts/scriptlib.fsx
+++ b/src/scripts/scriptlib.fsx
@@ -93,7 +93,7 @@ module Scripting =
 
     module Process =
 
-        let processExePath baseDir exe =
+        let processExePath baseDir (exe:string) =
             if Path.IsPathRooted(exe) then exe
             else 
                 match Path.GetDirectoryName(exe) with


### PR DESCRIPTION
.NET Core, and Mono after merging https://github.com/mono/mono/pull/11342, introduce ambiguity with a new overload.