### PR TITLE
Async.Sleep: TimeSpan -> Async<unit>

### DIFF
--- a/src/fsharp/FSharp.Core/async.fs
+++ b/src/fsharp/FSharp.Core/async.fs
@@ -1379,6 +1379,9 @@ namespace Microsoft.FSharp.Control
                     fake()
                 | _ -> 
                     ctxt.econt edi)
+
+        static member Sleep(dueTime: TimeSpan) : Async<unit> =
+            Async.Sleep (int dueTime.TotalMilliseconds)
         
         /// Wait for a wait handle. Both timeout and cancellation are supported
         static member AwaitWaitHandle(waitHandle: WaitHandle, ?millisecondsTimeout:int) =

--- a/src/fsharp/FSharp.Core/async.fsi
+++ b/src/fsharp/FSharp.Core/async.fsi
@@ -253,6 +253,15 @@ namespace Microsoft.FSharp.Control
         /// and not infinite.</exception>
         static member Sleep: millisecondsDueTime:int -> Async<unit>
 
+        /// <summary>Creates an asynchronous computation that will sleep for the given time. This is scheduled
+        /// using a System.Threading.Timer object. The operation will not block operating system threads
+        /// for the duration of the wait.</summary>
+        /// <param name="dueTime">The time to sleep.</param>
+        /// <returns>An asynchronous computation that will sleep for the given time.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the due time is negative
+        /// and not infinite.</exception>
+        static member Sleep: dueTime:TimeSpan -> Async<unit>
+
         /// <summary>Creates an asynchronous computation in terms of a Begin/End pair of actions in 
         /// the style used in CLI APIs. For example, 
         ///     <c>Async.FromBeginEnd(ws.BeginGetWeather,ws.EndGetWeather)</c>


### PR DESCRIPTION
Add an overload of `Async.Sleep` that takes a `TimeSpan` for convenience.